### PR TITLE
GAS section address

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -70,7 +70,8 @@ module.exports = grammar({
 
         word: $ => /[a-zA-Z0-9_]+/,
         _reg: $ => /%?[a-z0-9]+/,
-        reg: $ => choice($._reg, $.word),
+        address: $ => /\$[a-zA-Z0-9_]+/, // GAS x86 address
+        reg: $ => choice($._reg, $.word, $.address),
         meta_ident: $ => /\.[a-z_]+/,
         _ident: $ => /[a-zA-Z_0-9.]+/,
         ident: $ => choice($._ident, $.meta_ident, $.reg),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -503,6 +503,10 @@
       "type": "PATTERN",
       "value": "%?[a-z0-9]+"
     },
+    "address": {
+      "type": "PATTERN",
+      "value": "\\$[a-zA-Z0-9_]+"
+    },
     "reg": {
       "type": "CHOICE",
       "members": [
@@ -513,6 +517,10 @@
         {
           "type": "SYMBOL",
           "name": "word"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "address"
         }
       ]
     },
@@ -607,3 +615,4 @@
   "inline": [],
   "supertypes": []
 }
+

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -615,4 +615,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -182,6 +182,10 @@
       "required": false,
       "types": [
         {
+          "type": "address",
+          "named": true
+        },
+        {
           "type": "word",
           "named": true
         }
@@ -233,6 +237,10 @@
     "named": false
   },
   {
+    "type": "address",
+    "named": true
+  },
+  {
     "type": "block_comment",
     "named": true
   },
@@ -270,10 +278,10 @@
   },
   {
     "type": "word",
-    "named": false
+    "named": true
   },
   {
     "type": "word",
-    "named": true
+    "named": false
   }
 ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,21 +1,22 @@
-#include "tree_sitter/parser.h"
+#include <tree_sitter/parser.h>
 
 #if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
 #define LANGUAGE_VERSION 14
 #define STATE_COUNT 77
-#define LARGE_STATE_COUNT 5
-#define SYMBOL_COUNT 46
+#define LARGE_STATE_COUNT 6
+#define SYMBOL_COUNT 47
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 29
+#define TOKEN_COUNT 30
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 1
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
 #define PRODUCTION_ID_COUNT 3
 
-enum ts_symbol_identifiers {
+enum {
   anon_sym_LF = 1,
   anon_sym_COMMA = 2,
   anon_sym_COLON = 3,
@@ -39,28 +40,29 @@ enum ts_symbol_identifiers {
   sym_string = 21,
   sym_word = 22,
   sym__reg = 23,
-  sym_meta_ident = 24,
-  sym__ident = 25,
-  aux_sym_line_comment_token1 = 26,
-  aux_sym_line_comment_token2 = 27,
-  sym_block_comment = 28,
-  sym_program = 29,
-  sym__item = 30,
-  sym_meta = 31,
-  sym_label = 32,
-  sym_instruction = 33,
-  sym__expr = 34,
-  sym_ptr = 35,
-  sym_int = 36,
-  sym_reg = 37,
-  sym_ident = 38,
-  sym_line_comment = 39,
-  aux_sym_program_repeat1 = 40,
-  aux_sym_program_repeat2 = 41,
-  aux_sym_meta_repeat1 = 42,
-  aux_sym_meta_repeat2 = 43,
-  aux_sym_meta_repeat3 = 44,
-  aux_sym_instruction_repeat1 = 45,
+  sym_address = 24,
+  sym_meta_ident = 25,
+  sym__ident = 26,
+  aux_sym_line_comment_token1 = 27,
+  aux_sym_line_comment_token2 = 28,
+  sym_block_comment = 29,
+  sym_program = 30,
+  sym__item = 31,
+  sym_meta = 32,
+  sym_label = 33,
+  sym_instruction = 34,
+  sym__expr = 35,
+  sym_ptr = 36,
+  sym_int = 37,
+  sym_reg = 38,
+  sym_ident = 39,
+  sym_line_comment = 40,
+  aux_sym_program_repeat1 = 41,
+  aux_sym_program_repeat2 = 42,
+  aux_sym_meta_repeat1 = 43,
+  aux_sym_meta_repeat2 = 44,
+  aux_sym_meta_repeat3 = 45,
+  aux_sym_instruction_repeat1 = 46,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -88,6 +90,7 @@ static const char * const ts_symbol_names[] = {
   [sym_string] = "string",
   [sym_word] = "word",
   [sym__reg] = "_reg",
+  [sym_address] = "address",
   [sym_meta_ident] = "meta_ident",
   [sym__ident] = "_ident",
   [aux_sym_line_comment_token1] = "line_comment_token1",
@@ -137,6 +140,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_string] = sym_string,
   [sym_word] = sym_word,
   [sym__reg] = sym__reg,
+  [sym_address] = sym_address,
   [sym_meta_ident] = sym_meta_ident,
   [sym__ident] = sym__ident,
   [aux_sym_line_comment_token1] = aux_sym_line_comment_token1,
@@ -258,6 +262,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
+  [sym_address] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_meta_ident] = {
     .visible = true,
     .named = true,
@@ -348,7 +356,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-enum ts_field_identifiers {
+enum {
   field_kind = 1,
 };
 
@@ -462,63 +470,64 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(23);
+      if (eof) ADVANCE(25);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
-      if (lookahead == '\n') ADVANCE(24);
+      if (lookahead == '\n') ADVANCE(26);
       if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(42);
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '(') ADVANCE(27);
-      if (lookahead == ')') ADVANCE(28);
-      if (lookahead == '*') ADVANCE(39);
-      if (lookahead == '+') ADVANCE(36);
-      if (lookahead == ',') ADVANCE(25);
-      if (lookahead == '-') ADVANCE(37);
-      if (lookahead == '.') ADVANCE(91);
+      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '$') ADVANCE(21);
+      if (lookahead == '%') ADVANCE(20);
+      if (lookahead == '(') ADVANCE(29);
+      if (lookahead == ')') ADVANCE(30);
+      if (lookahead == '*') ADVANCE(41);
+      if (lookahead == '+') ADVANCE(38);
+      if (lookahead == ',') ADVANCE(27);
+      if (lookahead == '-') ADVANCE(39);
+      if (lookahead == '.') ADVANCE(95);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ':') ADVANCE(26);
-      if (lookahead == ';') ADVANCE(98);
-      if (lookahead == '[') ADVANCE(35);
-      if (lookahead == ']') ADVANCE(38);
-      if (lookahead == 'b') ADVANCE(82);
-      if (lookahead == 'd') ADVANCE(80);
-      if (lookahead == 'p') ADVANCE(78);
-      if (lookahead == 'q') ADVANCE(81);
-      if (lookahead == 'r') ADVANCE(68);
-      if (lookahead == 'w') ADVANCE(71);
+      if (lookahead == ':') ADVANCE(28);
+      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == '[') ADVANCE(37);
+      if (lookahead == ']') ADVANCE(40);
+      if (lookahead == 'b') ADVANCE(85);
+      if (lookahead == 'd') ADVANCE(83);
+      if (lookahead == 'p') ADVANCE(81);
+      if (lookahead == 'q') ADVANCE(84);
+      if (lookahead == 'r') ADVANCE(71);
+      if (lookahead == 'w') ADVANCE(74);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(64);
+      if (lookahead == '"') ADVANCE(67);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
-      if (lookahead == '$') ADVANCE(16);
-      if (lookahead == '0') ADVANCE(55);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(56);
-      END_STATE();
-    case 3:
-      if (lookahead == '$') ADVANCE(16);
+      if (lookahead == '$') ADVANCE(17);
       if (lookahead == '0') ADVANCE(57);
       if (('1' <= lookahead && lookahead <= '9')) ADVANCE(58);
       END_STATE();
-    case 4:
+    case 3:
       if (lookahead == '$') ADVANCE(17);
-      if (lookahead == '0') ADVANCE(44);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(45);
+      if (lookahead == '0') ADVANCE(59);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      END_STATE();
+    case 4:
+      if (lookahead == '$') ADVANCE(18);
+      if (lookahead == '0') ADVANCE(46);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
       END_STATE();
     case 5:
       if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(98);
+      if (lookahead == '/') ADVANCE(102);
       END_STATE();
     case 6:
       if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(99);
+      if (lookahead == '/') ADVANCE(103);
       if (lookahead != 0) ADVANCE(7);
       END_STATE();
     case 7:
@@ -529,10 +538,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'e') ADVANCE(9);
       END_STATE();
     case 9:
-      if (lookahead == 'l') ADVANCE(40);
+      if (lookahead == 'l') ADVANCE(42);
       END_STATE();
     case 10:
-      if (lookahead == 'r') ADVANCE(33);
+      if (lookahead == 'r') ADVANCE(35);
       END_STATE();
     case 11:
       if (lookahead == 't') ADVANCE(10);
@@ -541,660 +550,692 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(12)
-      if (lookahead == '#') ADVANCE(42);
+      if (lookahead == '#') ADVANCE(44);
       if (lookahead == '$') ADVANCE(16);
-      if (lookahead == '%') ADVANCE(19);
+      if (lookahead == '%') ADVANCE(20);
       if (lookahead == '-') ADVANCE(3);
-      if (lookahead == '.') ADVANCE(91);
+      if (lookahead == '.') ADVANCE(95);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(47);
-      if (lookahead == ';') ADVANCE(98);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(48);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      if (lookahead == '0') ADVANCE(49);
+      if (lookahead == ';') ADVANCE(102);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(50);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       END_STATE();
     case 13:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(13)
-      if (lookahead == '#') ADVANCE(42);
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '.') ADVANCE(91);
+      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '$') ADVANCE(21);
+      if (lookahead == '%') ADVANCE(20);
+      if (lookahead == '.') ADVANCE(95);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ';') ADVANCE(98);
+      if (lookahead == ';') ADVANCE(102);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 14:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(15)
-      if (lookahead == '#') ADVANCE(42);
-      if (lookahead == '$') ADVANCE(17);
+      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '$') ADVANCE(18);
       if (lookahead == '-') ADVANCE(4);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(44);
-      if (lookahead == ';') ADVANCE(98);
+      if (lookahead == '0') ADVANCE(46);
+      if (lookahead == ';') ADVANCE(102);
       if (lookahead == 'p') ADVANCE(11);
       if (lookahead == 'r') ADVANCE(8);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(45);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
       END_STATE();
     case 15:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(15)
-      if (lookahead == '#') ADVANCE(42);
+      if (lookahead == '#') ADVANCE(44);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ';') ADVANCE(98);
+      if (lookahead == ';') ADVANCE(102);
       if (lookahead == 'p') ADVANCE(11);
       if (lookahead == 'r') ADVANCE(8);
       END_STATE();
     case 16:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(59);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(61);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(92);
       END_STATE();
     case 17:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(46);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(62);
       END_STATE();
     case 18:
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(48);
       END_STATE();
     case 19:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(94);
       END_STATE();
     case 20:
-      if (eof) ADVANCE(23);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(20)
-      if (lookahead == '\n') ADVANCE(24);
-      if (lookahead == '#') ADVANCE(42);
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '.') ADVANCE(18);
-      if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ';') ADVANCE(98);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(87);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(86);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(91);
       END_STATE();
     case 21:
-      if (eof) ADVANCE(23);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(21)
-      if (lookahead == '\n') ADVANCE(24);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(42);
-      if (lookahead == '$') ADVANCE(16);
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '(') ADVANCE(27);
-      if (lookahead == '*') ADVANCE(39);
-      if (lookahead == '-') ADVANCE(2);
-      if (lookahead == '.') ADVANCE(91);
-      if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(52);
-      if (lookahead == ':') ADVANCE(26);
-      if (lookahead == ';') ADVANCE(98);
-      if (lookahead == '[') ADVANCE(35);
-      if (lookahead == 'b') ADVANCE(82);
-      if (lookahead == 'd') ADVANCE(80);
-      if (lookahead == 'q') ADVANCE(81);
-      if (lookahead == 'w') ADVANCE(71);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(53);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
       END_STATE();
     case 22:
-      if (eof) ADVANCE(23);
+      if (eof) ADVANCE(25);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(22)
-      if (lookahead == '\n') ADVANCE(24);
-      if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(42);
-      if (lookahead == '$') ADVANCE(16);
-      if (lookahead == '%') ADVANCE(19);
-      if (lookahead == '-') ADVANCE(2);
-      if (lookahead == '.') ADVANCE(91);
+      if (lookahead == '\n') ADVANCE(26);
+      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '$') ADVANCE(21);
+      if (lookahead == '%') ADVANCE(20);
+      if (lookahead == '.') ADVANCE(19);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(52);
-      if (lookahead == ':') ADVANCE(26);
-      if (lookahead == ';') ADVANCE(98);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(53);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      if (lookahead == ';') ADVANCE(102);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (eof) ADVANCE(25);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(23)
+      if (lookahead == '\n') ADVANCE(26);
+      if (lookahead == '"') ADVANCE(1);
+      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '$') ADVANCE(16);
+      if (lookahead == '%') ADVANCE(20);
+      if (lookahead == '(') ADVANCE(29);
+      if (lookahead == '*') ADVANCE(41);
+      if (lookahead == '-') ADVANCE(2);
+      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '/') ADVANCE(5);
+      if (lookahead == '0') ADVANCE(54);
+      if (lookahead == ':') ADVANCE(28);
+      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == '[') ADVANCE(37);
+      if (lookahead == 'b') ADVANCE(85);
+      if (lookahead == 'd') ADVANCE(83);
+      if (lookahead == 'q') ADVANCE(84);
+      if (lookahead == 'w') ADVANCE(74);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(anon_sym_LF);
+      if (eof) ADVANCE(25);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(24)
+      if (lookahead == '\n') ADVANCE(26);
+      if (lookahead == '"') ADVANCE(1);
+      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '$') ADVANCE(16);
+      if (lookahead == '%') ADVANCE(20);
+      if (lookahead == '-') ADVANCE(2);
+      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '/') ADVANCE(5);
+      if (lookahead == '0') ADVANCE(54);
+      if (lookahead == ':') ADVANCE(28);
+      if (lookahead == ';') ADVANCE(102);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(92);
+      ACCEPT_TOKEN(anon_sym_byte);
+      if (lookahead == '.') ADVANCE(96);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(92);
+      ACCEPT_TOKEN(anon_sym_word);
+      if (lookahead == '.') ADVANCE(96);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_ptr);
+      ACCEPT_TOKEN(anon_sym_dword);
+      if (lookahead == '.') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(anon_sym_ptr);
-      if (lookahead == '.') ADVANCE(92);
+      ACCEPT_TOKEN(anon_sym_qword);
+      if (lookahead == '.') ADVANCE(96);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 35:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(anon_sym_ptr);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_ptr);
+      if (lookahead == '.') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 39:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(anon_sym_rel);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 41:
-      ACCEPT_TOKEN(anon_sym_rel);
-      if (lookahead == '.') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(anon_sym_POUND);
+      ACCEPT_TOKEN(anon_sym_rel);
       END_STATE();
     case 43:
-      ACCEPT_TOKEN(anon_sym_POUND);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(97);
+      ACCEPT_TOKEN(anon_sym_rel);
+      if (lookahead == '.') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 44:
-      ACCEPT_TOKEN(aux_sym_int_token1);
-      if (lookahead == 'x') ADVANCE(17);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(45);
+      ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
     case 45:
-      ACCEPT_TOKEN(aux_sym_int_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(45);
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(101);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(aux_sym_int_token1);
+      if (lookahead == 'x') ADVANCE(18);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(47);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(aux_sym_int_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(47);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(aux_sym_int_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(46);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == '_') ADVANCE(50);
-      if (lookahead == 'x') ADVANCE(83);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(48);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(85);
-      END_STATE();
-    case 48:
-      ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == '_') ADVANCE(50);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(48);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(85);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(48);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_') ADVANCE(51);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(85);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '_') ADVANCE(52);
+      if (lookahead == 'x') ADVANCE(86);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(50);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(92);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(50);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(85);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '_') ADVANCE(52);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(50);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(92);
+      if (lookahead == '.') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_') ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(85);
+      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(60);
-      if (lookahead == '_') ADVANCE(54);
-      if (lookahead == 'x') ADVANCE(83);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(53);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(85);
+      if (lookahead == '.') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(52);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(60);
-      if (lookahead == '_') ADVANCE(54);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(53);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(85);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      if (lookahead == '.') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(53);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(60);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(54);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(85);
+      if (lookahead == '.') ADVANCE(63);
+      if (lookahead == '_') ADVANCE(56);
+      if (lookahead == 'x') ADVANCE(86);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(55);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(61);
-      if (lookahead == 'x') ADVANCE(16);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(56);
+      if (lookahead == '.') ADVANCE(63);
+      if (lookahead == '_') ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(55);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(61);
+      if (lookahead == '.') ADVANCE(63);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(56);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == 'x') ADVANCE(16);
+      if (lookahead == '.') ADVANCE(64);
+      if (lookahead == 'x') ADVANCE(17);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(58);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(aux_sym_int_token2);
+      if (lookahead == '.') ADVANCE(64);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(58);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(aux_sym_int_token2);
+      if (lookahead == 'x') ADVANCE(17);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(60);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(aux_sym_int_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(60);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(aux_sym_int_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(59);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(62);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(63);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(61);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(92);
       END_STATE();
     case 62:
-      ACCEPT_TOKEN(sym_float);
+      ACCEPT_TOKEN(aux_sym_int_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(62);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(62);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(63);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(65);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
       END_STATE();
     case 64:
-      ACCEPT_TOKEN(sym_string);
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(66);
       END_STATE();
     case 65:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'd') ADVANCE(30);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+      ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          lookahead == '_') ADVANCE(65);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
       END_STATE();
     case 66:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'd') ADVANCE(31);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+      ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          lookahead == '_') ADVANCE(66);
       END_STATE();
     case 67:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'd') ADVANCE(32);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+      ACCEPT_TOKEN(sym_string);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'e') ADVANCE(70);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'd') ADVANCE(32);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'e') ADVANCE(29);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'd') ADVANCE(33);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'l') ADVANCE(41);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'd') ADVANCE(34);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'o') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'e') ADVANCE(73);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'o') ADVANCE(76);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'e') ADVANCE(31);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'o') ADVANCE(77);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'l') ADVANCE(43);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'r') ADVANCE(34);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'o') ADVANCE(78);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'r') ADVANCE(65);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'o') ADVANCE(79);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'r') ADVANCE(66);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'o') ADVANCE(80);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'r') ADVANCE(67);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(36);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 't') ADVANCE(74);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(68);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 't') ADVANCE(69);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(69);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'w') ADVANCE(72);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(70);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'w') ADVANCE(73);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 't') ADVANCE(77);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (lookahead == 'y') ADVANCE(79);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 't') ADVANCE(72);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(51);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'w') ADVANCE(75);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(84);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'w') ADVANCE(76);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(85);
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(92);
+      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == 'y') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(85);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_word);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(87);
+      if (lookahead == '.') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(53);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(86);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
       END_STATE();
     case 87:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(sym_word);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(90);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
+      END_STATE();
+    case 90:
       ACCEPT_TOKEN(sym_word);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
-      END_STATE();
-    case 88:
-      ACCEPT_TOKEN(sym__reg);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(92);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(90);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(sym__ident);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(92);
+      ACCEPT_TOKEN(sym__reg);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(91);
       END_STATE();
     case 92:
-      ACCEPT_TOKEN(sym__ident);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(sym_address);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(7);
-      if (lookahead == '*') ADVANCE(93);
-      if (lookahead == '/') ADVANCE(97);
-      if (lookahead != 0) ADVANCE(94);
+      ACCEPT_TOKEN(sym_meta_ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(96);
       END_STATE();
     case 94:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(7);
-      if (lookahead == '*') ADVANCE(93);
-      if (lookahead != 0) ADVANCE(94);
+      ACCEPT_TOKEN(sym_meta_ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(94);
       END_STATE();
     case 95:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '*') ADVANCE(94);
-      if (lookahead == '/') ADVANCE(97);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(97);
+      ACCEPT_TOKEN(sym__ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(96);
       END_STATE();
     case 96:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(96);
-      if (lookahead == '#') ADVANCE(43);
-      if (lookahead == '/') ADVANCE(95);
-      if (lookahead == ';') ADVANCE(97);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(97);
+      ACCEPT_TOKEN(sym__ident);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(97);
+      if (lookahead == '\n') ADVANCE(7);
+      if (lookahead == '*') ADVANCE(97);
+      if (lookahead == '/') ADVANCE(101);
+      if (lookahead != 0) ADVANCE(98);
       END_STATE();
     case 98:
-      ACCEPT_TOKEN(aux_sym_line_comment_token2);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(98);
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '\n') ADVANCE(7);
+      if (lookahead == '*') ADVANCE(97);
+      if (lookahead != 0) ADVANCE(98);
       END_STATE();
     case 99:
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '*') ADVANCE(98);
+      if (lookahead == '/') ADVANCE(101);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(101);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(100);
+      if (lookahead == '#') ADVANCE(45);
+      if (lookahead == '/') ADVANCE(99);
+      if (lookahead == ';') ADVANCE(101);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(101);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(101);
+      END_STATE();
+    case 102:
+      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(102);
+      END_STATE();
+    case 103:
       ACCEPT_TOKEN(sym_block_comment);
       END_STATE();
     default:
@@ -1204,27 +1245,27 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 20},
-  [2] = {.lex_state = 21},
-  [3] = {.lex_state = 21},
-  [4] = {.lex_state = 21},
-  [5] = {.lex_state = 21},
-  [6] = {.lex_state = 22},
-  [7] = {.lex_state = 20},
-  [8] = {.lex_state = 20},
-  [9] = {.lex_state = 12},
-  [10] = {.lex_state = 20},
-  [11] = {.lex_state = 12},
-  [12] = {.lex_state = 0},
+  [1] = {.lex_state = 22},
+  [2] = {.lex_state = 23},
+  [3] = {.lex_state = 23},
+  [4] = {.lex_state = 23},
+  [5] = {.lex_state = 23},
+  [6] = {.lex_state = 24},
+  [7] = {.lex_state = 12},
+  [8] = {.lex_state = 12},
+  [9] = {.lex_state = 22},
+  [10] = {.lex_state = 22},
+  [11] = {.lex_state = 22},
+  [12] = {.lex_state = 13},
   [13] = {.lex_state = 13},
-  [14] = {.lex_state = 13},
+  [14] = {.lex_state = 0},
   [15] = {.lex_state = 0},
-  [16] = {.lex_state = 20},
+  [16] = {.lex_state = 22},
   [17] = {.lex_state = 0},
   [18] = {.lex_state = 0},
   [19] = {.lex_state = 0},
   [20] = {.lex_state = 0},
-  [21] = {.lex_state = 0},
+  [21] = {.lex_state = 22},
   [22] = {.lex_state = 0},
   [23] = {.lex_state = 0},
   [24] = {.lex_state = 0},
@@ -1234,50 +1275,50 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [28] = {.lex_state = 0},
   [29] = {.lex_state = 0},
   [30] = {.lex_state = 0},
-  [31] = {.lex_state = 0},
-  [32] = {.lex_state = 20},
+  [31] = {.lex_state = 22},
+  [32] = {.lex_state = 22},
   [33] = {.lex_state = 0},
   [34] = {.lex_state = 0},
-  [35] = {.lex_state = 0},
-  [36] = {.lex_state = 20},
+  [35] = {.lex_state = 22},
+  [36] = {.lex_state = 0},
   [37] = {.lex_state = 0},
-  [38] = {.lex_state = 0},
+  [38] = {.lex_state = 22},
   [39] = {.lex_state = 0},
-  [40] = {.lex_state = 20},
+  [40] = {.lex_state = 0},
   [41] = {.lex_state = 0},
   [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
   [44] = {.lex_state = 0},
-  [45] = {.lex_state = 20},
+  [45] = {.lex_state = 0},
   [46] = {.lex_state = 0},
   [47] = {.lex_state = 0},
   [48] = {.lex_state = 0},
   [49] = {.lex_state = 0},
   [50] = {.lex_state = 0},
   [51] = {.lex_state = 0},
-  [52] = {.lex_state = 20},
+  [52] = {.lex_state = 0},
   [53] = {.lex_state = 0},
-  [54] = {.lex_state = 0},
-  [55] = {.lex_state = 21},
+  [54] = {.lex_state = 23},
+  [55] = {.lex_state = 0},
   [56] = {.lex_state = 0},
   [57] = {.lex_state = 0},
-  [58] = {.lex_state = 0},
-  [59] = {.lex_state = 21},
+  [58] = {.lex_state = 23},
+  [59] = {.lex_state = 0},
   [60] = {.lex_state = 0},
   [61] = {.lex_state = 0},
-  [62] = {.lex_state = 0},
-  [63] = {.lex_state = 0},
-  [64] = {.lex_state = 14},
+  [62] = {.lex_state = 100},
+  [63] = {.lex_state = 14},
+  [64] = {.lex_state = 0},
   [65] = {.lex_state = 14},
   [66] = {.lex_state = 14},
   [67] = {.lex_state = 0},
   [68] = {.lex_state = 0},
   [69] = {.lex_state = 0},
-  [70] = {.lex_state = 0},
+  [70] = {.lex_state = 23},
   [71] = {.lex_state = 0},
-  [72] = {.lex_state = 21},
+  [72] = {.lex_state = 0},
   [73] = {.lex_state = 0},
-  [74] = {.lex_state = 96},
+  [74] = {.lex_state = 0},
   [75] = {(TSStateId)(-1)},
   [76] = {(TSStateId)(-1)},
 };
@@ -1306,17 +1347,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_string] = ACTIONS(1),
     [sym_word] = ACTIONS(1),
     [sym__reg] = ACTIONS(1),
+    [sym_address] = ACTIONS(1),
     [sym_meta_ident] = ACTIONS(1),
     [sym__ident] = ACTIONS(1),
     [aux_sym_line_comment_token2] = ACTIONS(5),
     [sym_block_comment] = ACTIONS(7),
   },
   [1] = {
-    [sym_program] = STATE(70),
-    [sym__item] = STATE(21),
-    [sym_meta] = STATE(56),
-    [sym_label] = STATE(56),
-    [sym_instruction] = STATE(56),
+    [sym_program] = STATE(69),
+    [sym__item] = STATE(22),
+    [sym_meta] = STATE(59),
+    [sym_label] = STATE(59),
+    [sym_instruction] = STATE(59),
     [sym_line_comment] = STATE(1),
     [ts_builtin_sym_end] = ACTIONS(9),
     [anon_sym_POUND] = ACTIONS(3),
@@ -1327,10 +1369,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
   [2] = {
     [sym__expr] = STATE(25),
-    [sym_ptr] = STATE(46),
+    [sym_ptr] = STATE(40),
     [sym_int] = STATE(26),
     [sym_reg] = STATE(15),
-    [sym_ident] = STATE(46),
+    [sym_ident] = STATE(40),
     [sym_line_comment] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(15),
     [anon_sym_LF] = ACTIONS(15),
@@ -1348,17 +1390,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_string] = ACTIONS(33),
     [sym_word] = ACTIONS(35),
     [sym__reg] = ACTIONS(35),
+    [sym_address] = ACTIONS(35),
     [sym_meta_ident] = ACTIONS(37),
     [sym__ident] = ACTIONS(37),
     [aux_sym_line_comment_token2] = ACTIONS(5),
     [sym_block_comment] = ACTIONS(7),
   },
   [3] = {
-    [sym__expr] = STATE(37),
-    [sym_ptr] = STATE(46),
+    [sym__expr] = STATE(49),
+    [sym_ptr] = STATE(40),
     [sym_int] = STATE(26),
     [sym_reg] = STATE(15),
-    [sym_ident] = STATE(46),
+    [sym_ident] = STATE(40),
     [sym_line_comment] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(39),
     [anon_sym_LF] = ACTIONS(39),
@@ -1375,17 +1418,18 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_string] = ACTIONS(33),
     [sym_word] = ACTIONS(35),
     [sym__reg] = ACTIONS(35),
+    [sym_address] = ACTIONS(35),
     [sym_meta_ident] = ACTIONS(37),
     [sym__ident] = ACTIONS(37),
     [aux_sym_line_comment_token2] = ACTIONS(5),
     [sym_block_comment] = ACTIONS(7),
   },
   [4] = {
-    [sym__expr] = STATE(37),
-    [sym_ptr] = STATE(46),
+    [sym__expr] = STATE(49),
+    [sym_ptr] = STATE(40),
     [sym_int] = STATE(26),
     [sym_reg] = STATE(15),
-    [sym_ident] = STATE(46),
+    [sym_ident] = STATE(40),
     [sym_line_comment] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(41),
     [anon_sym_LF] = ACTIONS(41),
@@ -1402,6 +1446,33 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_string] = ACTIONS(33),
     [sym_word] = ACTIONS(35),
     [sym__reg] = ACTIONS(35),
+    [sym_address] = ACTIONS(35),
+    [sym_meta_ident] = ACTIONS(37),
+    [sym__ident] = ACTIONS(37),
+    [aux_sym_line_comment_token2] = ACTIONS(5),
+    [sym_block_comment] = ACTIONS(7),
+  },
+  [5] = {
+    [sym__expr] = STATE(49),
+    [sym_ptr] = STATE(40),
+    [sym_int] = STATE(26),
+    [sym_reg] = STATE(15),
+    [sym_ident] = STATE(40),
+    [sym_line_comment] = STATE(5),
+    [anon_sym_LPAREN] = ACTIONS(19),
+    [anon_sym_byte] = ACTIONS(21),
+    [anon_sym_word] = ACTIONS(21),
+    [anon_sym_dword] = ACTIONS(21),
+    [anon_sym_qword] = ACTIONS(21),
+    [anon_sym_LBRACK] = ACTIONS(23),
+    [anon_sym_STAR] = ACTIONS(25),
+    [anon_sym_POUND] = ACTIONS(27),
+    [aux_sym_int_token2] = ACTIONS(29),
+    [sym_float] = ACTIONS(31),
+    [sym_string] = ACTIONS(33),
+    [sym_word] = ACTIONS(35),
+    [sym__reg] = ACTIONS(35),
+    [sym_address] = ACTIONS(35),
     [sym_meta_ident] = ACTIONS(37),
     [sym__ident] = ACTIONS(37),
     [aux_sym_line_comment_token2] = ACTIONS(5),
@@ -1410,48 +1481,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 17,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(19), 1,
-      anon_sym_LPAREN,
-    ACTIONS(23), 1,
-      anon_sym_LBRACK,
-    ACTIONS(25), 1,
-      anon_sym_STAR,
-    ACTIONS(27), 1,
-      anon_sym_POUND,
-    ACTIONS(29), 1,
-      aux_sym_int_token2,
-    ACTIONS(31), 1,
-      sym_float,
-    ACTIONS(33), 1,
-      sym_string,
-    STATE(5), 1,
-      sym_line_comment,
-    STATE(15), 1,
-      sym_reg,
-    STATE(26), 1,
-      sym_int,
-    STATE(37), 1,
-      sym__expr,
-    ACTIONS(35), 2,
-      sym_word,
-      sym__reg,
-    ACTIONS(37), 2,
-      sym_meta_ident,
-      sym__ident,
-    STATE(46), 2,
-      sym_ptr,
-      sym_ident,
-    ACTIONS(21), 4,
-      anon_sym_byte,
-      anon_sym_word,
-      anon_sym_dword,
-      anon_sym_qword,
-  [58] = 14,
+  [0] = 14,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -1474,16 +1504,63 @@ static const uint16_t ts_small_parse_table[] = {
       sym_int,
     STATE(57), 1,
       sym_ident,
-    ACTIONS(35), 2,
-      sym_word,
-      sym__reg,
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
     ACTIONS(43), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [104] = 11,
+    ACTIONS(35), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+  [47] = 9,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(27), 1,
+      anon_sym_POUND,
+    ACTIONS(29), 1,
+      aux_sym_int_token2,
+    STATE(7), 1,
+      sym_line_comment,
+    STATE(15), 1,
+      sym_reg,
+    ACTIONS(37), 2,
+      sym_meta_ident,
+      sym__ident,
+    STATE(73), 2,
+      sym_int,
+      sym_ident,
+    ACTIONS(35), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+  [79] = 9,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(27), 1,
+      anon_sym_POUND,
+    ACTIONS(29), 1,
+      aux_sym_int_token2,
+    STATE(8), 1,
+      sym_line_comment,
+    STATE(15), 1,
+      sym_reg,
+    ACTIONS(37), 2,
+      sym_meta_ident,
+      sym__ident,
+    STATE(68), 2,
+      sym_int,
+      sym_ident,
+    ACTIONS(35), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+  [111] = 11,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1498,17 +1575,17 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
     ACTIONS(53), 1,
       anon_sym_LF,
-    STATE(7), 1,
+    STATE(9), 1,
       sym_line_comment,
     STATE(16), 1,
       aux_sym_program_repeat1,
-    STATE(54), 1,
+    STATE(55), 1,
       sym__item,
-    STATE(56), 3,
+    STATE(59), 3,
       sym_meta,
       sym_label,
       sym_instruction,
-  [140] = 11,
+  [147] = 11,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1523,39 +1600,17 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF,
     ACTIONS(55), 1,
       ts_builtin_sym_end,
-    STATE(8), 1,
+    STATE(10), 1,
       sym_line_comment,
     STATE(16), 1,
       aux_sym_program_repeat1,
-    STATE(54), 1,
+    STATE(55), 1,
       sym__item,
-    STATE(56), 3,
+    STATE(59), 3,
       sym_meta,
       sym_label,
       sym_instruction,
-  [176] = 9,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(27), 1,
-      anon_sym_POUND,
-    ACTIONS(29), 1,
-      aux_sym_int_token2,
-    STATE(9), 1,
-      sym_line_comment,
-    STATE(15), 1,
-      sym_reg,
-    ACTIONS(35), 2,
-      sym_word,
-      sym__reg,
-    ACTIONS(37), 2,
-      sym_meta_ident,
-      sym__ident,
-    STATE(73), 2,
-      sym_int,
-      sym_ident,
-  [207] = 10,
+  [183] = 10,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1568,67 +1623,51 @@ static const uint16_t ts_small_parse_table[] = {
       sym_meta_ident,
     ACTIONS(53), 1,
       anon_sym_LF,
-    STATE(10), 1,
+    STATE(11), 1,
       sym_line_comment,
     STATE(16), 1,
       aux_sym_program_repeat1,
-    STATE(54), 1,
+    STATE(55), 1,
       sym__item,
-    STATE(56), 3,
+    STATE(59), 3,
       sym_meta,
       sym_label,
       sym_instruction,
-  [240] = 9,
+  [216] = 9,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(27), 1,
-      anon_sym_POUND,
-    ACTIONS(29), 1,
-      aux_sym_int_token2,
-    STATE(11), 1,
+    ACTIONS(57), 1,
+      sym_address,
+    STATE(12), 1,
       sym_line_comment,
     STATE(15), 1,
       sym_reg,
+    STATE(61), 1,
+      sym_ident,
     ACTIONS(35), 2,
       sym_word,
       sym__reg,
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(69), 2,
-      sym_int,
-      sym_ident,
-  [271] = 5,
+  [246] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(12), 1,
-      sym_line_comment,
-    ACTIONS(57), 7,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_RBRACK,
-  [293] = 8,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
+    ACTIONS(57), 1,
+      sym_address,
     STATE(13), 1,
       sym_line_comment,
     STATE(15), 1,
       sym_reg,
-    STATE(60), 1,
+    STATE(67), 1,
       sym_ident,
     ACTIONS(35), 2,
       sym_word,
@@ -1636,7 +1675,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
-  [320] = 8,
+  [276] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1645,17 +1684,15 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(14), 1,
       sym_line_comment,
-    STATE(15), 1,
-      sym_reg,
-    STATE(62), 1,
-      sym_ident,
-    ACTIONS(35), 2,
-      sym_word,
-      sym__reg,
-    ACTIONS(37), 2,
-      sym_meta_ident,
-      sym__ident,
-  [347] = 5,
+    ACTIONS(59), 7,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_RBRACK,
+  [298] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1664,29 +1701,29 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(15), 1,
       sym_line_comment,
-    ACTIONS(59), 5,
+    ACTIONS(61), 5,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [367] = 6,
+  [318] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(63), 1,
+    ACTIONS(65), 1,
       anon_sym_LF,
     STATE(16), 2,
       sym_line_comment,
       aux_sym_program_repeat1,
-    ACTIONS(61), 3,
+    ACTIONS(63), 3,
       ts_builtin_sym_end,
       sym_word,
       sym_meta_ident,
-  [389] = 5,
+  [340] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1695,13 +1732,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(17), 1,
       sym_line_comment,
-    ACTIONS(66), 5,
+    ACTIONS(68), 5,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
       anon_sym_LPAREN,
       anon_sym_RBRACK,
-  [409] = 5,
+  [360] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1710,20 +1747,20 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(18), 1,
       sym_line_comment,
-    ACTIONS(68), 5,
+    ACTIONS(70), 5,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
       anon_sym_LPAREN,
       anon_sym_RBRACK,
-  [429] = 7,
+  [380] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(70), 1,
+    ACTIONS(72), 1,
       anon_sym_COMMA,
     STATE(19), 1,
       sym_line_comment,
@@ -1732,23 +1769,38 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(41), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [452] = 7,
+  [403] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(74), 1,
+    ACTIONS(76), 1,
       anon_sym_COMMA,
-    STATE(20), 1,
-      sym_line_comment,
-    STATE(23), 1,
-      aux_sym_meta_repeat3,
-    ACTIONS(72), 2,
+    ACTIONS(74), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [475] = 8,
+    STATE(20), 2,
+      sym_line_comment,
+      aux_sym_meta_repeat3,
+  [424] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(35), 1,
+      sym__reg,
+    STATE(21), 1,
+      sym_line_comment,
+    STATE(43), 1,
+      sym_reg,
+    ACTIONS(57), 2,
+      sym_word,
+      sym_address,
+  [447] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1757,106 +1809,107 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(53), 1,
       anon_sym_LF,
-    ACTIONS(76), 1,
+    ACTIONS(79), 1,
       ts_builtin_sym_end,
-    STATE(8), 1,
+    STATE(10), 1,
       aux_sym_program_repeat1,
-    STATE(21), 1,
+    STATE(22), 1,
       sym_line_comment,
     STATE(33), 1,
       aux_sym_program_repeat2,
-  [500] = 6,
+  [472] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(80), 1,
+    ACTIONS(83), 1,
       anon_sym_COMMA,
-    ACTIONS(78), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(22), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat1,
-  [521] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(85), 1,
-      anon_sym_COMMA,
-    ACTIONS(83), 2,
+    ACTIONS(81), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
     STATE(23), 2,
       sym_line_comment,
-      aux_sym_meta_repeat3,
-  [542] = 6,
+      aux_sym_meta_repeat1,
+  [493] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(90), 1,
+    ACTIONS(88), 1,
       anon_sym_COMMA,
-    ACTIONS(88), 2,
+    ACTIONS(86), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
     STATE(24), 2,
       sym_line_comment,
       aux_sym_meta_repeat2,
-  [563] = 7,
+  [514] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(95), 1,
+    ACTIONS(93), 1,
       anon_sym_COMMA,
     STATE(19), 1,
       aux_sym_instruction_repeat1,
     STATE(25), 1,
       sym_line_comment,
-    ACTIONS(93), 2,
+    ACTIONS(91), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [586] = 6,
+  [537] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(99), 1,
+    ACTIONS(97), 1,
       anon_sym_LPAREN,
     STATE(26), 1,
       sym_line_comment,
-    ACTIONS(97), 3,
+    ACTIONS(95), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [607] = 6,
+  [558] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(103), 1,
+    ACTIONS(101), 1,
       anon_sym_COMMA,
-    ACTIONS(101), 2,
+    ACTIONS(99), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
     STATE(27), 2,
       sym_line_comment,
       aux_sym_instruction_repeat1,
-  [628] = 7,
+  [579] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(106), 1,
+      anon_sym_COMMA,
+    STATE(28), 1,
+      sym_line_comment,
+    STATE(39), 1,
+      aux_sym_meta_repeat2,
+    ACTIONS(104), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [602] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1865,30 +1918,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(108), 1,
       anon_sym_COMMA,
-    STATE(28), 1,
-      sym_line_comment,
-    STATE(35), 1,
-      aux_sym_meta_repeat2,
-    ACTIONS(106), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [651] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(74), 1,
-      anon_sym_COMMA,
-    STATE(20), 1,
-      aux_sym_meta_repeat3,
     STATE(29), 1,
       sym_line_comment,
-    ACTIONS(106), 2,
+    STATE(37), 1,
+      aux_sym_meta_repeat3,
+    ACTIONS(104), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [674] = 7,
+  [625] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1899,28 +1936,28 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
     STATE(30), 1,
       sym_line_comment,
-    STATE(34), 1,
+    STATE(36), 1,
       aux_sym_meta_repeat1,
-    ACTIONS(106), 2,
+    ACTIONS(104), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [697] = 7,
+  [648] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(112), 1,
-      ts_builtin_sym_end,
-    ACTIONS(114), 1,
-      anon_sym_LF,
-    STATE(10), 1,
-      aux_sym_program_repeat1,
-    STATE(31), 2,
+    ACTIONS(35), 1,
+      sym__reg,
+    STATE(31), 1,
       sym_line_comment,
-      aux_sym_program_repeat2,
-  [720] = 5,
+    STATE(46), 1,
+      sym_reg,
+    ACTIONS(57), 2,
+      sym_word,
+      sym_address,
+  [671] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1929,12 +1966,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(32), 1,
       sym_line_comment,
-    ACTIONS(117), 4,
+    ACTIONS(112), 4,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_word,
       sym_meta_ident,
-  [739] = 8,
+  [690] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1945,13 +1982,45 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF,
     ACTIONS(55), 1,
       ts_builtin_sym_end,
-    STATE(7), 1,
+    STATE(9), 1,
       aux_sym_program_repeat1,
-    STATE(31), 1,
-      aux_sym_program_repeat2,
     STATE(33), 1,
       sym_line_comment,
-  [764] = 7,
+    STATE(34), 1,
+      aux_sym_program_repeat2,
+  [715] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(114), 1,
+      ts_builtin_sym_end,
+    ACTIONS(116), 1,
+      anon_sym_LF,
+    STATE(11), 1,
+      aux_sym_program_repeat1,
+    STATE(34), 2,
+      sym_line_comment,
+      aux_sym_program_repeat2,
+  [738] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(35), 1,
+      sym__reg,
+    STATE(35), 1,
+      sym_line_comment,
+    STATE(60), 1,
+      sym_reg,
+    ACTIONS(57), 2,
+      sym_word,
+      sym_address,
+  [761] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1960,14 +2029,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(110), 1,
       anon_sym_COMMA,
-    STATE(22), 1,
+    STATE(23), 1,
       aux_sym_meta_repeat1,
-    STATE(34), 1,
+    STATE(36), 1,
       sym_line_comment,
-    ACTIONS(72), 2,
+    ACTIONS(119), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [787] = 7,
+  [784] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1976,69 +2045,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(108), 1,
       anon_sym_COMMA,
-    STATE(24), 1,
-      aux_sym_meta_repeat2,
-    STATE(35), 1,
-      sym_line_comment,
-    ACTIONS(72), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [810] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(35), 1,
-      sym__reg,
-    ACTIONS(119), 1,
-      sym_word,
-    STATE(36), 1,
-      sym_line_comment,
-    STATE(63), 1,
-      sym_reg,
-  [832] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
+    STATE(20), 1,
+      aux_sym_meta_repeat3,
     STATE(37), 1,
       sym_line_comment,
-    ACTIONS(101), 3,
+    ACTIONS(119), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-  [850] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(123), 1,
-      anon_sym_RBRACK,
-    STATE(38), 1,
-      sym_line_comment,
-    ACTIONS(121), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [870] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(39), 1,
-      sym_line_comment,
-    ACTIONS(125), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [888] = 7,
+  [807] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2047,13 +2061,43 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(35), 1,
       sym__reg,
-    ACTIONS(119), 1,
+    STATE(38), 1,
+      sym_line_comment,
+    STATE(64), 1,
+      sym_reg,
+    ACTIONS(57), 2,
       sym_word,
+      sym_address,
+  [830] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(106), 1,
+      anon_sym_COMMA,
+    STATE(24), 1,
+      aux_sym_meta_repeat2,
+    STATE(39), 1,
+      sym_line_comment,
+    ACTIONS(119), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [853] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
     STATE(40), 1,
       sym_line_comment,
-    STATE(68), 1,
-      sym_reg,
-  [910] = 5,
+    ACTIONS(95), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [871] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2062,11 +2106,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(41), 1,
       sym_line_comment,
-    ACTIONS(127), 3,
+    ACTIONS(121), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [928] = 5,
+  [889] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2075,25 +2119,25 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(42), 1,
       sym_line_comment,
-    ACTIONS(129), 3,
+    ACTIONS(123), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [946] = 6,
+  [907] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(133), 1,
+    ACTIONS(127), 1,
       anon_sym_RBRACK,
     STATE(43), 1,
       sym_line_comment,
-    ACTIONS(131), 2,
+    ACTIONS(125), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
-  [966] = 5,
+  [927] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2102,39 +2146,39 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(44), 1,
       sym_line_comment,
-    ACTIONS(78), 3,
+    ACTIONS(129), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [984] = 7,
+  [945] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(35), 1,
-      sym__reg,
-    ACTIONS(119), 1,
-      sym_word,
-    STATE(38), 1,
-      sym_reg,
+    ACTIONS(133), 1,
+      anon_sym_LPAREN,
     STATE(45), 1,
       sym_line_comment,
-  [1006] = 5,
+    ACTIONS(131), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [965] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(137), 1,
+      anon_sym_RBRACK,
     STATE(46), 1,
       sym_line_comment,
-    ACTIONS(97), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [1024] = 5,
+    ACTIONS(135), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [985] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2143,52 +2187,51 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(47), 1,
       sym_line_comment,
-    ACTIONS(83), 3,
+    ACTIONS(139), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1042] = 6,
+  [1003] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(137), 1,
-      anon_sym_LPAREN,
     STATE(48), 1,
       sym_line_comment,
-    ACTIONS(135), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1062] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(141), 1,
-      anon_sym_LPAREN,
-    STATE(49), 1,
-      sym_line_comment,
-    ACTIONS(139), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1082] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(50), 1,
-      sym_line_comment,
-    ACTIONS(88), 3,
+    ACTIONS(81), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1100] = 5,
+  [1021] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(49), 1,
+      sym_line_comment,
+    ACTIONS(99), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [1039] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(143), 1,
+      anon_sym_LPAREN,
+    STATE(50), 1,
+      sym_line_comment,
+    ACTIONS(141), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [1059] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2197,26 +2240,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(51), 1,
       sym_line_comment,
-    ACTIONS(143), 3,
+    ACTIONS(74), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1118] = 7,
+  [1077] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(35), 1,
-      sym__reg,
-    ACTIONS(119), 1,
-      sym_word,
-    STATE(43), 1,
-      sym_reg,
     STATE(52), 1,
       sym_line_comment,
-  [1140] = 5,
+    ACTIONS(86), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [1095] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2228,19 +2269,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(145), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1157] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(54), 1,
-      sym_line_comment,
-    ACTIONS(112), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1174] = 6,
+  [1112] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2249,11 +2278,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_POUND,
     ACTIONS(147), 1,
       aux_sym_int_token2,
+    STATE(48), 1,
+      sym_int,
+    STATE(54), 1,
+      sym_line_comment,
+  [1131] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
     STATE(55), 1,
       sym_line_comment,
-    STATE(69), 1,
-      sym_int,
-  [1193] = 5,
+    ACTIONS(114), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [1148] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2265,7 +2306,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(149), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1210] = 5,
+  [1165] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2274,22 +2315,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(57), 1,
       sym_line_comment,
-    ACTIONS(106), 2,
+    ACTIONS(104), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1227] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(58), 1,
-      sym_line_comment,
-    ACTIONS(151), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1244] = 6,
+  [1182] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2298,11 +2327,34 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_POUND,
     ACTIONS(147), 1,
       aux_sym_int_token2,
-    STATE(44), 1,
+    STATE(58), 1,
+      sym_line_comment,
+    STATE(68), 1,
       sym_int,
+  [1201] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
     STATE(59), 1,
       sym_line_comment,
-  [1263] = 5,
+    ACTIONS(151), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [1218] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(127), 1,
+      anon_sym_RPAREN,
+    STATE(60), 1,
+      sym_line_comment,
+  [1234] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2311,64 +2363,20 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(153), 1,
       anon_sym_RPAREN,
-    STATE(60), 1,
-      sym_line_comment,
-  [1279] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(155), 1,
-      anon_sym_LBRACK,
     STATE(61), 1,
       sym_line_comment,
-  [1295] = 5,
-    ACTIONS(3), 1,
+  [1250] = 5,
+    ACTIONS(155), 1,
       anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
     ACTIONS(157), 1,
-      anon_sym_RPAREN,
+      aux_sym_line_comment_token1,
+    ACTIONS(159), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(161), 1,
+      sym_block_comment,
     STATE(62), 1,
       sym_line_comment,
-  [1311] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(123), 1,
-      anon_sym_RPAREN,
-    STATE(63), 1,
-      sym_line_comment,
-  [1327] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(159), 1,
-      anon_sym_ptr,
-    STATE(64), 1,
-      sym_line_comment,
-  [1343] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(161), 1,
-      aux_sym_int_token1,
-    STATE(65), 1,
-      sym_line_comment,
-  [1359] = 5,
+  [1266] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2376,10 +2384,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(163), 1,
-      anon_sym_rel,
-    STATE(66), 1,
+      anon_sym_ptr,
+    STATE(63), 1,
       sym_line_comment,
-  [1375] = 5,
+  [1282] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2387,10 +2395,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(165), 1,
-      anon_sym_LBRACK,
-    STATE(67), 1,
+      anon_sym_RPAREN,
+    STATE(64), 1,
       sym_line_comment,
-  [1391] = 5,
+  [1298] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2398,21 +2406,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(167), 1,
-      anon_sym_RPAREN,
-    STATE(68), 1,
+      aux_sym_int_token1,
+    STATE(65), 1,
       sym_line_comment,
-  [1407] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(133), 1,
-      anon_sym_RBRACK,
-    STATE(69), 1,
-      sym_line_comment,
-  [1423] = 5,
+  [1314] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2420,10 +2417,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(169), 1,
-      ts_builtin_sym_end,
-    STATE(70), 1,
+      anon_sym_rel,
+    STATE(66), 1,
       sym_line_comment,
-  [1439] = 5,
+  [1330] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2431,10 +2428,21 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(171), 1,
-      sym_string,
-    STATE(71), 1,
+      anon_sym_RPAREN,
+    STATE(67), 1,
       sym_line_comment,
-  [1455] = 5,
+  [1346] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(137), 1,
+      anon_sym_RBRACK,
+    STATE(68), 1,
+      sym_line_comment,
+  [1362] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2442,10 +2450,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(173), 1,
-      sym_float,
-    STATE(72), 1,
+      ts_builtin_sym_end,
+    STATE(69), 1,
       sym_line_comment,
-  [1471] = 5,
+  [1378] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2453,194 +2461,226 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(175), 1,
+      sym_float,
+    STATE(70), 1,
+      sym_line_comment,
+  [1394] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(177), 1,
+      anon_sym_LBRACK,
+    STATE(71), 1,
+      sym_line_comment,
+  [1410] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(179), 1,
+      anon_sym_LBRACK,
+    STATE(72), 1,
+      sym_line_comment,
+  [1426] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(181), 1,
       anon_sym_RBRACK,
     STATE(73), 1,
       sym_line_comment,
-  [1487] = 5,
-    ACTIONS(177), 1,
+  [1442] = 5,
+    ACTIONS(3), 1,
       anon_sym_POUND,
-    ACTIONS(179), 1,
-      aux_sym_line_comment_token1,
-    ACTIONS(181), 1,
+    ACTIONS(5), 1,
       aux_sym_line_comment_token2,
-    ACTIONS(183), 1,
+    ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(183), 1,
+      sym_string,
     STATE(74), 1,
       sym_line_comment,
-  [1503] = 1,
+  [1458] = 1,
     ACTIONS(185), 1,
       ts_builtin_sym_end,
-  [1507] = 1,
+  [1462] = 1,
     ACTIONS(187), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(5)] = 0,
-  [SMALL_STATE(6)] = 58,
-  [SMALL_STATE(7)] = 104,
-  [SMALL_STATE(8)] = 140,
-  [SMALL_STATE(9)] = 176,
-  [SMALL_STATE(10)] = 207,
-  [SMALL_STATE(11)] = 240,
-  [SMALL_STATE(12)] = 271,
-  [SMALL_STATE(13)] = 293,
-  [SMALL_STATE(14)] = 320,
-  [SMALL_STATE(15)] = 347,
-  [SMALL_STATE(16)] = 367,
-  [SMALL_STATE(17)] = 389,
-  [SMALL_STATE(18)] = 409,
-  [SMALL_STATE(19)] = 429,
-  [SMALL_STATE(20)] = 452,
-  [SMALL_STATE(21)] = 475,
-  [SMALL_STATE(22)] = 500,
-  [SMALL_STATE(23)] = 521,
-  [SMALL_STATE(24)] = 542,
-  [SMALL_STATE(25)] = 563,
-  [SMALL_STATE(26)] = 586,
-  [SMALL_STATE(27)] = 607,
-  [SMALL_STATE(28)] = 628,
-  [SMALL_STATE(29)] = 651,
-  [SMALL_STATE(30)] = 674,
-  [SMALL_STATE(31)] = 697,
-  [SMALL_STATE(32)] = 720,
-  [SMALL_STATE(33)] = 739,
-  [SMALL_STATE(34)] = 764,
-  [SMALL_STATE(35)] = 787,
-  [SMALL_STATE(36)] = 810,
-  [SMALL_STATE(37)] = 832,
-  [SMALL_STATE(38)] = 850,
-  [SMALL_STATE(39)] = 870,
-  [SMALL_STATE(40)] = 888,
-  [SMALL_STATE(41)] = 910,
-  [SMALL_STATE(42)] = 928,
-  [SMALL_STATE(43)] = 946,
-  [SMALL_STATE(44)] = 966,
-  [SMALL_STATE(45)] = 984,
-  [SMALL_STATE(46)] = 1006,
-  [SMALL_STATE(47)] = 1024,
-  [SMALL_STATE(48)] = 1042,
-  [SMALL_STATE(49)] = 1062,
-  [SMALL_STATE(50)] = 1082,
-  [SMALL_STATE(51)] = 1100,
-  [SMALL_STATE(52)] = 1118,
-  [SMALL_STATE(53)] = 1140,
-  [SMALL_STATE(54)] = 1157,
-  [SMALL_STATE(55)] = 1174,
-  [SMALL_STATE(56)] = 1193,
-  [SMALL_STATE(57)] = 1210,
-  [SMALL_STATE(58)] = 1227,
-  [SMALL_STATE(59)] = 1244,
-  [SMALL_STATE(60)] = 1263,
-  [SMALL_STATE(61)] = 1279,
-  [SMALL_STATE(62)] = 1295,
-  [SMALL_STATE(63)] = 1311,
-  [SMALL_STATE(64)] = 1327,
-  [SMALL_STATE(65)] = 1343,
-  [SMALL_STATE(66)] = 1359,
-  [SMALL_STATE(67)] = 1375,
-  [SMALL_STATE(68)] = 1391,
-  [SMALL_STATE(69)] = 1407,
-  [SMALL_STATE(70)] = 1423,
-  [SMALL_STATE(71)] = 1439,
-  [SMALL_STATE(72)] = 1455,
-  [SMALL_STATE(73)] = 1471,
-  [SMALL_STATE(74)] = 1487,
-  [SMALL_STATE(75)] = 1503,
-  [SMALL_STATE(76)] = 1507,
+  [SMALL_STATE(6)] = 0,
+  [SMALL_STATE(7)] = 47,
+  [SMALL_STATE(8)] = 79,
+  [SMALL_STATE(9)] = 111,
+  [SMALL_STATE(10)] = 147,
+  [SMALL_STATE(11)] = 183,
+  [SMALL_STATE(12)] = 216,
+  [SMALL_STATE(13)] = 246,
+  [SMALL_STATE(14)] = 276,
+  [SMALL_STATE(15)] = 298,
+  [SMALL_STATE(16)] = 318,
+  [SMALL_STATE(17)] = 340,
+  [SMALL_STATE(18)] = 360,
+  [SMALL_STATE(19)] = 380,
+  [SMALL_STATE(20)] = 403,
+  [SMALL_STATE(21)] = 424,
+  [SMALL_STATE(22)] = 447,
+  [SMALL_STATE(23)] = 472,
+  [SMALL_STATE(24)] = 493,
+  [SMALL_STATE(25)] = 514,
+  [SMALL_STATE(26)] = 537,
+  [SMALL_STATE(27)] = 558,
+  [SMALL_STATE(28)] = 579,
+  [SMALL_STATE(29)] = 602,
+  [SMALL_STATE(30)] = 625,
+  [SMALL_STATE(31)] = 648,
+  [SMALL_STATE(32)] = 671,
+  [SMALL_STATE(33)] = 690,
+  [SMALL_STATE(34)] = 715,
+  [SMALL_STATE(35)] = 738,
+  [SMALL_STATE(36)] = 761,
+  [SMALL_STATE(37)] = 784,
+  [SMALL_STATE(38)] = 807,
+  [SMALL_STATE(39)] = 830,
+  [SMALL_STATE(40)] = 853,
+  [SMALL_STATE(41)] = 871,
+  [SMALL_STATE(42)] = 889,
+  [SMALL_STATE(43)] = 907,
+  [SMALL_STATE(44)] = 927,
+  [SMALL_STATE(45)] = 945,
+  [SMALL_STATE(46)] = 965,
+  [SMALL_STATE(47)] = 985,
+  [SMALL_STATE(48)] = 1003,
+  [SMALL_STATE(49)] = 1021,
+  [SMALL_STATE(50)] = 1039,
+  [SMALL_STATE(51)] = 1059,
+  [SMALL_STATE(52)] = 1077,
+  [SMALL_STATE(53)] = 1095,
+  [SMALL_STATE(54)] = 1112,
+  [SMALL_STATE(55)] = 1131,
+  [SMALL_STATE(56)] = 1148,
+  [SMALL_STATE(57)] = 1165,
+  [SMALL_STATE(58)] = 1182,
+  [SMALL_STATE(59)] = 1201,
+  [SMALL_STATE(60)] = 1218,
+  [SMALL_STATE(61)] = 1234,
+  [SMALL_STATE(62)] = 1250,
+  [SMALL_STATE(63)] = 1266,
+  [SMALL_STATE(64)] = 1282,
+  [SMALL_STATE(65)] = 1298,
+  [SMALL_STATE(66)] = 1314,
+  [SMALL_STATE(67)] = 1330,
+  [SMALL_STATE(68)] = 1346,
+  [SMALL_STATE(69)] = 1362,
+  [SMALL_STATE(70)] = 1378,
+  [SMALL_STATE(71)] = 1394,
+  [SMALL_STATE(72)] = 1410,
+  [SMALL_STATE(73)] = 1426,
+  [SMALL_STATE(74)] = 1442,
+  [SMALL_STATE(75)] = 1458,
+  [SMALL_STATE(76)] = 1462,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
   [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 1, .production_id = 1),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(64),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
   [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
   [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
   [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
   [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
   [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, .production_id = 1),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, .production_id = 1),
   [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 1, .production_id = 1),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
   [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
   [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
   [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3),
   [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
   [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1),
-  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ident, 1),
-  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(32),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 2),
-  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, .production_id = 1),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [76] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2),
-  [80] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2), SHIFT_REPEAT(59),
-  [83] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2),
-  [85] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2), SHIFT_REPEAT(71),
-  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2),
-  [90] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2), SHIFT_REPEAT(72),
-  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, .production_id = 1),
-  [95] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [97] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1),
-  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [101] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2),
-  [103] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2), SHIFT_REPEAT(5),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, .production_id = 1),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2),
-  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2), SHIFT_REPEAT(32),
-  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1),
-  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [125] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7),
-  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1),
+  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ident, 1),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(32),
+  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 2),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1),
+  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2),
+  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2), SHIFT_REPEAT(74),
+  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2),
+  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2), SHIFT_REPEAT(54),
+  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2),
+  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2), SHIFT_REPEAT(70),
+  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, .production_id = 1),
+  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1),
+  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2),
+  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2), SHIFT_REPEAT(5),
+  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, .production_id = 1),
+  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1),
+  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2),
+  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2), SHIFT_REPEAT(32),
+  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, .production_id = 1),
+  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7),
+  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
   [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, .production_id = 2),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2),
-  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, .production_id = 2),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, .production_id = 2),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5),
   [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
-  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [169] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [179] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
-  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [183] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, .production_id = 2),
+  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [155] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [157] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
+  [159] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
+  [161] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [173] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
   [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2),
   [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1),
 };
@@ -2649,12 +2689,10 @@ static const TSParseActionEntry ts_parse_actions[] = {
 extern "C" {
 #endif
 #ifdef _WIN32
-#define TS_PUBLIC __declspec(dllexport)
-#else
-#define TS_PUBLIC __attribute__((visibility("default")))
+#define extern __declspec(dllexport)
 #endif
 
-TS_PUBLIC const TSLanguage *tree_sitter_asm() {
+extern const TSLanguage *tree_sitter_asm(void) {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,7 +1,6 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 
 #if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
@@ -16,7 +15,7 @@
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
 #define PRODUCTION_ID_COUNT 3
 
-enum {
+enum ts_symbol_identifiers {
   anon_sym_LF = 1,
   anon_sym_COMMA = 2,
   anon_sym_COLON = 3,
@@ -356,7 +355,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-enum {
+enum ts_field_identifiers {
   field_kind = 1,
 };
 
@@ -2689,10 +2688,12 @@ static const TSParseActionEntry ts_parse_actions[] = {
 extern "C" {
 #endif
 #ifdef _WIN32
-#define extern __declspec(dllexport)
+#define TS_PUBLIC __declspec(dllexport)
+#else
+#define TS_PUBLIC __attribute__((visibility("default")))
 #endif
 
-extern const TSLanguage *tree_sitter_asm(void) {
+TS_PUBLIC const TSLanguage *tree_sitter_asm() {
   static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -130,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -166,7 +172,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +182,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +190,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -129,16 +130,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -172,7 +166,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -182,7 +176,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -190,7 +184,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/instr_and_reg.test
+++ b/test/corpus/instr_and_reg.test
@@ -79,6 +79,21 @@ adr X1, helloworld
               (reg
               (word)))))
 
+==========
+Instruction -- Section address arg, reg arg (GAS x86)
+==========
+mov $msg, %ecx
+---
+(program
+    (instruction
+        (word)
+        (ident
+            (reg
+                (address)))
+         (ident
+              (reg))))
+
+==========
 Instruction -- Dotted label arg
 ==========
 jne	.L5

--- a/test/corpus/instr_and_reg.test
+++ b/test/corpus/instr_and_reg.test
@@ -4,7 +4,7 @@ Instruction -- No args
 MOVLPS
 ---
 (program
-    (instruction kind: (word))) 
+    (instruction kind: (word)))
 
 ==========
 Instruction -- One reg arg
@@ -41,7 +41,7 @@ movzbl	-1(%rbp), %eax
         (ident (reg))))
 
 ==========
-Instruction -- Integer immediate arg, reg arg
+Instruction -- Integer immediate arg, reg arg (GAS x86)
 ==========
 andl	$15, %eax
 ---
@@ -52,6 +52,33 @@ andl	$15, %eax
         (ident (reg))))
 
 ==========
+Instruction -- Reg arg, Integer immediate arg (ARM A64)
+==========
+mov X10, #1
+---
+(program
+    (instruction
+        (word)
+        (ident
+            (reg
+                (word)))
+        (int)))
+
+==========
+Instruction -- Reg arg, section address arg (ARM A64)
+==========
+adr X1, helloworld
+---
+(program
+    (instruction
+        (word)
+        (ident
+            (reg
+                (word)))
+         (ident
+              (reg
+              (word)))))
+
 Instruction -- Dotted label arg
 ==========
 jne	.L5


### PR DESCRIPTION
I noticed on using `$` for section address reference on GAS x86 the parser was failing.

For instance, given this instruction `mov $msg, %ecx`.

**Before:**
```
(program [0, 0] - [1, 0]
  (instruction [0, 0] - [0, 14]
    kind: (word [0, 0] - [0, 3])
    (ERROR [0, 4] - [0, 5]
      (ERROR [0, 4] - [0, 5]))
    (ident [0, 5] - [0, 8]
      (reg [0, 5] - [0, 8]
        (word [0, 5] - [0, 8])))
    (ident [0, 10] - [0, 14]
      (reg [0, 10] - [0, 14]))))
```
**After:**
```
(program [0, 0] - [1, 0]
  (instruction [0, 0] - [0, 14]
    kind: (word [0, 0] - [0, 3])
    (ident [0, 4] - [0, 8]
      (reg [0, 4] - [0, 8]
        (address [0, 4] - [0, 8])))
    (ident [0, 10] - [0, 14]
      (reg [0, 10] - [0, 14]))))
```

**References about this syntax**

> ‘Address’ 
>    
> gcc / as: Prefix with ‘$’; for example $loc 
> Intel: No extra punctuation; for example loc
> https://gcc.gnu.org/onlinedocs/gnat_ugn/Basic-Assembler-Syntax.html

Example from https://en.wikibooks.org/wiki/X86_Assembly/GNU_assembly_syntax
```
        .text
LC0:
        .ascii "Hello, world!\12\0"
.globl _main
_main:
        pushl   %ebp
        movl    %esp, %ebp
        subl    $8, %esp
        andl    $-16, %esp
        movl    $0, %eax
        movl    %eax, -4(%ebp)
        movl    -4(%ebp), %eax
        call    __alloca
        call    ___main
        movl    $LC0, (%esp)
        call    _printf
        movl    $0, %eax
        leave
        ret
```
