### PR TITLE
Pointer reference arm64

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -56,6 +56,14 @@ module.exports = grammar({
                     $.int,
                     ']',
                 ),
+                // Aarch64
+                seq(
+                    '[',
+                    $.reg,
+                    optional(seq(',', $.int)),
+                    ']',
+                    optional('!')
+                ),
             ),
 
         int: $ => {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,18 @@
     "type": "git",
     "url": "https://github.com/rush-rs/tree-sitter-asm"
   },
-  "keywords": ["parser", "lexer"],
-  "files": ["grammar.js", "binding.gyp", "prebuilds/**", "bindings/node/*", "queries/*", "src/**"],
+  "keywords": [
+    "parser",
+    "lexer"
+  ],
+  "files": [
+    "grammar.js",
+    "binding.gyp",
+    "prebuilds/**",
+    "bindings/node/*",
+    "queries/*",
+    "src/**"
+  ],
   "author": "RubixDev",
   "license": "MIT",
   "dependencies": {
@@ -31,11 +41,16 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.7",
-    "prebuildify": "^6.0.0"
+    "prebuildify": "^6.0.0",
+    "tree-sitter-cli": "^0.22.2"
   },
-  "tree-sitter": [{
-    "scope": "source.asm",
-    "file-types": ["s", "asm"]
-  }]
+  "tree-sitter": [
+    {
+      "scope": "source.asm",
+      "file-types": [
+        "s",
+        "asm"
+      ]
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -14,18 +14,8 @@
     "type": "git",
     "url": "https://github.com/rush-rs/tree-sitter-asm"
   },
-  "keywords": [
-    "parser",
-    "lexer"
-  ],
-  "files": [
-    "grammar.js",
-    "binding.gyp",
-    "prebuilds/**",
-    "bindings/node/*",
-    "queries/*",
-    "src/**"
-  ],
+  "keywords": ["parser", "lexer"],
+  "files": ["grammar.js", "binding.gyp", "prebuilds/**", "bindings/node/*", "queries/*", "src/**"],
   "author": "RubixDev",
   "license": "MIT",
   "dependencies": {
@@ -44,13 +34,8 @@
     "prebuildify": "^6.0.0",
     "tree-sitter-cli": "^0.22.2"
   },
-  "tree-sitter": [
-    {
-      "scope": "source.asm",
-      "file-types": [
-        "s",
-        "asm"
-      ]
-    }
-  ]
+  "tree-sitter": [{
+    "scope": "source.asm",
+    "file-types": ["s", "asm"]
+  }]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -459,6 +459,56 @@
               "value": "]"
             }
           ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "SYMBOL",
+              "name": "reg"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "int"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "!"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -197,6 +197,10 @@
     "named": false
   },
   {
+    "type": "!",
+    "named": false
+  },
+  {
     "type": "#",
     "named": false
   },
@@ -278,10 +282,10 @@
   },
   {
     "type": "word",
-    "named": true
+    "named": false
   },
   {
     "type": "word",
-    "named": false
+    "named": true
   }
 ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,11 +5,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 77
-#define LARGE_STATE_COUNT 6
-#define SYMBOL_COUNT 47
+#define STATE_COUNT 82
+#define LARGE_STATE_COUNT 5
+#define SYMBOL_COUNT 48
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 30
+#define TOKEN_COUNT 31
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 1
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
@@ -32,36 +32,37 @@ enum ts_symbol_identifiers {
   anon_sym_RBRACK = 14,
   anon_sym_STAR = 15,
   anon_sym_rel = 16,
-  anon_sym_POUND = 17,
-  aux_sym_int_token1 = 18,
-  aux_sym_int_token2 = 19,
-  sym_float = 20,
-  sym_string = 21,
-  sym_word = 22,
-  sym__reg = 23,
-  sym_address = 24,
-  sym_meta_ident = 25,
-  sym__ident = 26,
-  aux_sym_line_comment_token1 = 27,
-  aux_sym_line_comment_token2 = 28,
-  sym_block_comment = 29,
-  sym_program = 30,
-  sym__item = 31,
-  sym_meta = 32,
-  sym_label = 33,
-  sym_instruction = 34,
-  sym__expr = 35,
-  sym_ptr = 36,
-  sym_int = 37,
-  sym_reg = 38,
-  sym_ident = 39,
-  sym_line_comment = 40,
-  aux_sym_program_repeat1 = 41,
-  aux_sym_program_repeat2 = 42,
-  aux_sym_meta_repeat1 = 43,
-  aux_sym_meta_repeat2 = 44,
-  aux_sym_meta_repeat3 = 45,
-  aux_sym_instruction_repeat1 = 46,
+  anon_sym_BANG = 17,
+  anon_sym_POUND = 18,
+  aux_sym_int_token1 = 19,
+  aux_sym_int_token2 = 20,
+  sym_float = 21,
+  sym_string = 22,
+  sym_word = 23,
+  sym__reg = 24,
+  sym_address = 25,
+  sym_meta_ident = 26,
+  sym__ident = 27,
+  aux_sym_line_comment_token1 = 28,
+  aux_sym_line_comment_token2 = 29,
+  sym_block_comment = 30,
+  sym_program = 31,
+  sym__item = 32,
+  sym_meta = 33,
+  sym_label = 34,
+  sym_instruction = 35,
+  sym__expr = 36,
+  sym_ptr = 37,
+  sym_int = 38,
+  sym_reg = 39,
+  sym_ident = 40,
+  sym_line_comment = 41,
+  aux_sym_program_repeat1 = 42,
+  aux_sym_program_repeat2 = 43,
+  aux_sym_meta_repeat1 = 44,
+  aux_sym_meta_repeat2 = 45,
+  aux_sym_meta_repeat3 = 46,
+  aux_sym_instruction_repeat1 = 47,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -82,6 +83,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RBRACK] = "]",
   [anon_sym_STAR] = "*",
   [anon_sym_rel] = "rel",
+  [anon_sym_BANG] = "!",
   [anon_sym_POUND] = "#",
   [aux_sym_int_token1] = "int_token1",
   [aux_sym_int_token2] = "int_token2",
@@ -132,6 +134,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RBRACK] = anon_sym_RBRACK,
   [anon_sym_STAR] = anon_sym_STAR,
   [anon_sym_rel] = anon_sym_rel,
+  [anon_sym_BANG] = anon_sym_BANG,
   [anon_sym_POUND] = anon_sym_POUND,
   [aux_sym_int_token1] = aux_sym_int_token1,
   [aux_sym_int_token2] = aux_sym_int_token2,
@@ -230,6 +233,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_rel] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_BANG] = {
     .visible = true,
     .named = false,
   },
@@ -462,6 +469,11 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [74] = 74,
   [75] = 75,
   [76] = 76,
+  [77] = 77,
+  [78] = 78,
+  [79] = 79,
+  [80] = 80,
+  [81] = 81,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -474,8 +486,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
       if (lookahead == '\n') ADVANCE(26);
+      if (lookahead == '!') ADVANCE(44);
       if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(21);
       if (lookahead == '%') ADVANCE(20);
       if (lookahead == '(') ADVANCE(29);
@@ -484,49 +497,49 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '+') ADVANCE(38);
       if (lookahead == ',') ADVANCE(27);
       if (lookahead == '-') ADVANCE(39);
-      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '.') ADVANCE(96);
       if (lookahead == '/') ADVANCE(5);
       if (lookahead == ':') ADVANCE(28);
-      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == ';') ADVANCE(103);
       if (lookahead == '[') ADVANCE(37);
       if (lookahead == ']') ADVANCE(40);
-      if (lookahead == 'b') ADVANCE(85);
-      if (lookahead == 'd') ADVANCE(83);
-      if (lookahead == 'p') ADVANCE(81);
-      if (lookahead == 'q') ADVANCE(84);
-      if (lookahead == 'r') ADVANCE(71);
-      if (lookahead == 'w') ADVANCE(74);
+      if (lookahead == 'b') ADVANCE(86);
+      if (lookahead == 'd') ADVANCE(84);
+      if (lookahead == 'p') ADVANCE(82);
+      if (lookahead == 'q') ADVANCE(85);
+      if (lookahead == 'r') ADVANCE(72);
+      if (lookahead == 'w') ADVANCE(75);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(67);
+      if (lookahead == '"') ADVANCE(68);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
       if (lookahead == '$') ADVANCE(17);
-      if (lookahead == '0') ADVANCE(57);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(58);
+      if (lookahead == '0') ADVANCE(58);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(59);
       END_STATE();
     case 3:
       if (lookahead == '$') ADVANCE(17);
-      if (lookahead == '0') ADVANCE(59);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(60);
+      if (lookahead == '0') ADVANCE(60);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(61);
       END_STATE();
     case 4:
       if (lookahead == '$') ADVANCE(18);
-      if (lookahead == '0') ADVANCE(46);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
+      if (lookahead == '0') ADVANCE(47);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(48);
       END_STATE();
     case 5:
       if (lookahead == '*') ADVANCE(7);
-      if (lookahead == '/') ADVANCE(102);
+      if (lookahead == '/') ADVANCE(103);
       END_STATE();
     case 6:
       if (lookahead == '*') ADVANCE(6);
-      if (lookahead == '/') ADVANCE(103);
+      if (lookahead == '/') ADVANCE(104);
       if (lookahead != 0) ADVANCE(7);
       END_STATE();
     case 7:
@@ -549,89 +562,89 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(12)
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(16);
       if (lookahead == '%') ADVANCE(20);
       if (lookahead == '-') ADVANCE(3);
-      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '.') ADVANCE(96);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(49);
-      if (lookahead == ';') ADVANCE(102);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(50);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (lookahead == '0') ADVANCE(50);
+      if (lookahead == ';') ADVANCE(103);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(51);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       END_STATE();
     case 13:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(13)
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(21);
       if (lookahead == '%') ADVANCE(20);
-      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '.') ADVANCE(96);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == ';') ADVANCE(103);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 14:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(15)
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(18);
       if (lookahead == '-') ADVANCE(4);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(46);
-      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == '0') ADVANCE(47);
+      if (lookahead == ';') ADVANCE(103);
       if (lookahead == 'p') ADVANCE(11);
       if (lookahead == 'r') ADVANCE(8);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(47);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(48);
       END_STATE();
     case 15:
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(15)
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == ';') ADVANCE(103);
       if (lookahead == 'p') ADVANCE(11);
       if (lookahead == 'r') ADVANCE(8);
       END_STATE();
     case 16:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(61);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(62);
       if (('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(92);
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 17:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(62);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(63);
       END_STATE();
     case 18:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(48);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
       END_STATE();
     case 19:
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(94);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
       END_STATE();
     case 20:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(91);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
       END_STATE();
     case 21:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 22:
       if (eof) ADVANCE(25);
@@ -639,16 +652,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '\r' ||
           lookahead == ' ') SKIP(22)
       if (lookahead == '\n') ADVANCE(26);
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(21);
       if (lookahead == '%') ADVANCE(20);
       if (lookahead == '.') ADVANCE(19);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == ';') ADVANCE(103);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(90);
+          lookahead == '_') ADVANCE(91);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(90);
       END_STATE();
     case 23:
       if (eof) ADVANCE(25);
@@ -657,26 +670,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(23)
       if (lookahead == '\n') ADVANCE(26);
       if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(16);
       if (lookahead == '%') ADVANCE(20);
       if (lookahead == '(') ADVANCE(29);
       if (lookahead == '*') ADVANCE(41);
       if (lookahead == '-') ADVANCE(2);
-      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '.') ADVANCE(96);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(54);
+      if (lookahead == '0') ADVANCE(55);
       if (lookahead == ':') ADVANCE(28);
-      if (lookahead == ';') ADVANCE(102);
+      if (lookahead == ';') ADVANCE(103);
       if (lookahead == '[') ADVANCE(37);
-      if (lookahead == 'b') ADVANCE(85);
-      if (lookahead == 'd') ADVANCE(83);
-      if (lookahead == 'q') ADVANCE(84);
-      if (lookahead == 'w') ADVANCE(74);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (lookahead == 'b') ADVANCE(86);
+      if (lookahead == 'd') ADVANCE(84);
+      if (lookahead == 'q') ADVANCE(85);
+      if (lookahead == 'w') ADVANCE(75);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       END_STATE();
     case 24:
       if (eof) ADVANCE(25);
@@ -685,19 +698,19 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(24)
       if (lookahead == '\n') ADVANCE(26);
       if (lookahead == '"') ADVANCE(1);
-      if (lookahead == '#') ADVANCE(44);
+      if (lookahead == '#') ADVANCE(45);
       if (lookahead == '$') ADVANCE(16);
       if (lookahead == '%') ADVANCE(20);
       if (lookahead == '-') ADVANCE(2);
-      if (lookahead == '.') ADVANCE(95);
+      if (lookahead == '.') ADVANCE(96);
       if (lookahead == '/') ADVANCE(5);
-      if (lookahead == '0') ADVANCE(54);
+      if (lookahead == '0') ADVANCE(55);
       if (lookahead == ':') ADVANCE(28);
-      if (lookahead == ';') ADVANCE(102);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (lookahead == ';') ADVANCE(103);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       END_STATE();
     case 25:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -719,46 +732,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 31:
       ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(anon_sym_ptr);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(anon_sym_ptr);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(anon_sym_LBRACK);
@@ -780,140 +793,134 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 43:
       ACCEPT_TOKEN(anon_sym_rel);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 44:
-      ACCEPT_TOKEN(anon_sym_POUND);
+      ACCEPT_TOKEN(anon_sym_BANG);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(anon_sym_POUND);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(101);
       END_STATE();
     case 46:
-      ACCEPT_TOKEN(aux_sym_int_token1);
-      if (lookahead == 'x') ADVANCE(18);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(47);
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(102);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(aux_sym_int_token1);
+      if (lookahead == 'x') ADVANCE(18);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(47);
+          lookahead == '_') ADVANCE(48);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(aux_sym_int_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(48);
+          lookahead == '_') ADVANCE(48);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == '_') ADVANCE(52);
-      if (lookahead == 'x') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(50);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
+      ACCEPT_TOKEN(aux_sym_int_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(49);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == '_') ADVANCE(52);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(50);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == '_') ADVANCE(53);
+      if (lookahead == 'x') ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(51);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(89);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_') ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == '_') ADVANCE(53);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(51);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(89);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_') ADVANCE(54);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(52);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(52);
+      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(89);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(53);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+          lookahead == '_') ADVANCE(53);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(63);
-      if (lookahead == '_') ADVANCE(56);
-      if (lookahead == 'x') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
+      if (lookahead == '.') ADVANCE(97);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(54);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(63);
-      if (lookahead == '_') ADVANCE(56);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(55);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(88);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      if (lookahead == '.') ADVANCE(64);
+      if (lookahead == '_') ADVANCE(57);
+      if (lookahead == 'x') ADVANCE(87);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(89);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(63);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(56);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+      if (lookahead == '.') ADVANCE(64);
+      if (lookahead == '_') ADVANCE(57);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(89);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(aux_sym_int_token2);
       if (lookahead == '.') ADVANCE(64);
-      if (lookahead == 'x') ADVANCE(17);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(58);
+          lookahead == '_') ADVANCE(57);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(64);
+      if (lookahead == '.') ADVANCE(65);
+      if (lookahead == 'x') ADVANCE(17);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(58);
+          lookahead == '_') ADVANCE(59);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == 'x') ADVANCE(17);
+      if (lookahead == '.') ADVANCE(65);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(60);
+          lookahead == '_') ADVANCE(59);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(aux_sym_int_token2);
+      if (lookahead == 'x') ADVANCE(17);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(60);
+          lookahead == '_') ADVANCE(61);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(aux_sym_int_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(61);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(92);
+          lookahead == '_') ADVANCE(61);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(aux_sym_int_token2);
@@ -921,320 +928,329 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(62);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(65);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+      ACCEPT_TOKEN(aux_sym_int_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(63);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(66);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(97);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(65);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(67);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(66);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(97);
       END_STATE();
     case 67:
-      ACCEPT_TOKEN(sym_string);
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(67);
       END_STATE();
     case 68:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'd') ADVANCE(32);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+      ACCEPT_TOKEN(sym_string);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'd') ADVANCE(33);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'd') ADVANCE(32);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'd') ADVANCE(34);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'd') ADVANCE(33);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'e') ADVANCE(73);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'd') ADVANCE(34);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'e') ADVANCE(31);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'e') ADVANCE(74);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'l') ADVANCE(43);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'e') ADVANCE(31);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'o') ADVANCE(78);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'l') ADVANCE(43);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (lookahead == 'o') ADVANCE(79);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (lookahead == 'o') ADVANCE(80);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'r') ADVANCE(36);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'o') ADVANCE(81);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'r') ADVANCE(68);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'r') ADVANCE(36);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (lookahead == 'r') ADVANCE(69);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (lookahead == 'r') ADVANCE(70);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 't') ADVANCE(77);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'r') ADVANCE(71);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 't') ADVANCE(72);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 't') ADVANCE(78);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'w') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 't') ADVANCE(73);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
       if (lookahead == 'w') ADVANCE(76);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (lookahead == 'y') ADVANCE(82);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'w') ADVANCE(77);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(53);
+      if (lookahead == '.') ADVANCE(97);
+      if (lookahead == 'y') ADVANCE(83);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(51);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(87);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(88);
+      if (lookahead == '.') ADVANCE(97);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(54);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(87);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(52);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(88);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(89);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(97);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(89);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(88);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_word);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(90);
+      if (lookahead == '.') ADVANCE(97);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym_word);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(91);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(90);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(sym__reg);
+      ACCEPT_TOKEN(sym_word);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(91);
       END_STATE();
     case 92:
+      ACCEPT_TOKEN(sym__reg);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
+      END_STATE();
+    case 93:
       ACCEPT_TOKEN(sym_address);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(92);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(96);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_meta_ident);
       if (lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(94);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(sym__ident);
-      if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(96);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(97);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(sym_meta_ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
       END_STATE();
     case 96:
+      ACCEPT_TOKEN(sym__ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(94);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(97);
+      END_STATE();
+    case 97:
       ACCEPT_TOKEN(sym__ident);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(96);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(7);
-      if (lookahead == '*') ADVANCE(97);
-      if (lookahead == '/') ADVANCE(101);
-      if (lookahead != 0) ADVANCE(98);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(97);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
       if (lookahead == '\n') ADVANCE(7);
-      if (lookahead == '*') ADVANCE(97);
-      if (lookahead != 0) ADVANCE(98);
+      if (lookahead == '*') ADVANCE(98);
+      if (lookahead == '/') ADVANCE(102);
+      if (lookahead != 0) ADVANCE(99);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '\n') ADVANCE(7);
       if (lookahead == '*') ADVANCE(98);
-      if (lookahead == '/') ADVANCE(101);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(101);
+      if (lookahead != 0) ADVANCE(99);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(100);
-      if (lookahead == '#') ADVANCE(45);
-      if (lookahead == '/') ADVANCE(99);
-      if (lookahead == ';') ADVANCE(101);
+      if (lookahead == '*') ADVANCE(99);
+      if (lookahead == '/') ADVANCE(102);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(101);
+          lookahead != '\n') ADVANCE(102);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(101);
+      if (lookahead == '#') ADVANCE(46);
+      if (lookahead == '/') ADVANCE(100);
+      if (lookahead == ';') ADVANCE(102);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(101);
+          lookahead != '\n') ADVANCE(102);
       END_STATE();
     case 102:
-      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(102);
       END_STATE();
     case 103:
+      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(103);
+      END_STATE();
+    case 104:
       ACCEPT_TOKEN(sym_block_comment);
       END_STATE();
     default:
@@ -1264,7 +1280,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [18] = {.lex_state = 0},
   [19] = {.lex_state = 0},
   [20] = {.lex_state = 0},
-  [21] = {.lex_state = 22},
+  [21] = {.lex_state = 0},
   [22] = {.lex_state = 0},
   [23] = {.lex_state = 0},
   [24] = {.lex_state = 0},
@@ -1273,17 +1289,17 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [27] = {.lex_state = 0},
   [28] = {.lex_state = 0},
   [29] = {.lex_state = 0},
-  [30] = {.lex_state = 0},
+  [30] = {.lex_state = 22},
   [31] = {.lex_state = 22},
-  [32] = {.lex_state = 22},
+  [32] = {.lex_state = 0},
   [33] = {.lex_state = 0},
   [34] = {.lex_state = 0},
-  [35] = {.lex_state = 22},
+  [35] = {.lex_state = 0},
   [36] = {.lex_state = 0},
   [37] = {.lex_state = 0},
   [38] = {.lex_state = 22},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 0},
+  [39] = {.lex_state = 22},
+  [40] = {.lex_state = 22},
   [41] = {.lex_state = 0},
   [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
@@ -1297,29 +1313,34 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [51] = {.lex_state = 0},
   [52] = {.lex_state = 0},
   [53] = {.lex_state = 0},
-  [54] = {.lex_state = 23},
+  [54] = {.lex_state = 0},
   [55] = {.lex_state = 0},
-  [56] = {.lex_state = 0},
+  [56] = {.lex_state = 23},
   [57] = {.lex_state = 0},
   [58] = {.lex_state = 23},
   [59] = {.lex_state = 0},
-  [60] = {.lex_state = 0},
+  [60] = {.lex_state = 23},
   [61] = {.lex_state = 0},
-  [62] = {.lex_state = 100},
-  [63] = {.lex_state = 14},
+  [62] = {.lex_state = 0},
+  [63] = {.lex_state = 0},
   [64] = {.lex_state = 0},
-  [65] = {.lex_state = 14},
+  [65] = {.lex_state = 0},
   [66] = {.lex_state = 14},
-  [67] = {.lex_state = 0},
+  [67] = {.lex_state = 23},
   [68] = {.lex_state = 0},
-  [69] = {.lex_state = 0},
-  [70] = {.lex_state = 23},
+  [69] = {.lex_state = 14},
+  [70] = {.lex_state = 0},
   [71] = {.lex_state = 0},
   [72] = {.lex_state = 0},
   [73] = {.lex_state = 0},
-  [74] = {.lex_state = 0},
-  [75] = {(TSStateId)(-1)},
-  [76] = {(TSStateId)(-1)},
+  [74] = {.lex_state = 101},
+  [75] = {.lex_state = 0},
+  [76] = {.lex_state = 14},
+  [77] = {.lex_state = 0},
+  [78] = {.lex_state = 0},
+  [79] = {.lex_state = 0},
+  [80] = {(TSStateId)(-1)},
+  [81] = {(TSStateId)(-1)},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1342,6 +1363,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
     [anon_sym_rel] = ACTIONS(1),
+    [anon_sym_BANG] = ACTIONS(1),
     [anon_sym_POUND] = ACTIONS(3),
     [sym_string] = ACTIONS(1),
     [sym_word] = ACTIONS(1),
@@ -1353,7 +1375,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [1] = {
-    [sym_program] = STATE(69),
+    [sym_program] = STATE(73),
     [sym__item] = STATE(22),
     [sym_meta] = STATE(59),
     [sym_label] = STATE(59),
@@ -1367,11 +1389,11 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [2] = {
-    [sym__expr] = STATE(25),
-    [sym_ptr] = STATE(40),
-    [sym_int] = STATE(26),
+    [sym__expr] = STATE(24),
+    [sym_ptr] = STATE(52),
+    [sym_int] = STATE(25),
     [sym_reg] = STATE(15),
-    [sym_ident] = STATE(40),
+    [sym_ident] = STATE(52),
     [sym_line_comment] = STATE(2),
     [ts_builtin_sym_end] = ACTIONS(15),
     [anon_sym_LF] = ACTIONS(15),
@@ -1396,11 +1418,11 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [3] = {
-    [sym__expr] = STATE(49),
-    [sym_ptr] = STATE(40),
-    [sym_int] = STATE(26),
+    [sym__expr] = STATE(55),
+    [sym_ptr] = STATE(52),
+    [sym_int] = STATE(25),
     [sym_reg] = STATE(15),
-    [sym_ident] = STATE(40),
+    [sym_ident] = STATE(52),
     [sym_line_comment] = STATE(3),
     [ts_builtin_sym_end] = ACTIONS(39),
     [anon_sym_LF] = ACTIONS(39),
@@ -1424,11 +1446,11 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [4] = {
-    [sym__expr] = STATE(49),
-    [sym_ptr] = STATE(40),
-    [sym_int] = STATE(26),
+    [sym__expr] = STATE(55),
+    [sym_ptr] = STATE(52),
+    [sym_int] = STATE(25),
     [sym_reg] = STATE(15),
-    [sym_ident] = STATE(40),
+    [sym_ident] = STATE(52),
     [sym_line_comment] = STATE(4),
     [ts_builtin_sym_end] = ACTIONS(41),
     [anon_sym_LF] = ACTIONS(41),
@@ -1451,36 +1473,52 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_line_comment_token2] = ACTIONS(5),
     [sym_block_comment] = ACTIONS(7),
   },
-  [5] = {
-    [sym__expr] = STATE(49),
-    [sym_ptr] = STATE(40),
-    [sym_int] = STATE(26),
-    [sym_reg] = STATE(15),
-    [sym_ident] = STATE(40),
-    [sym_line_comment] = STATE(5),
-    [anon_sym_LPAREN] = ACTIONS(19),
-    [anon_sym_byte] = ACTIONS(21),
-    [anon_sym_word] = ACTIONS(21),
-    [anon_sym_dword] = ACTIONS(21),
-    [anon_sym_qword] = ACTIONS(21),
-    [anon_sym_LBRACK] = ACTIONS(23),
-    [anon_sym_STAR] = ACTIONS(25),
-    [anon_sym_POUND] = ACTIONS(27),
-    [aux_sym_int_token2] = ACTIONS(29),
-    [sym_float] = ACTIONS(31),
-    [sym_string] = ACTIONS(33),
-    [sym_word] = ACTIONS(35),
-    [sym__reg] = ACTIONS(35),
-    [sym_address] = ACTIONS(35),
-    [sym_meta_ident] = ACTIONS(37),
-    [sym__ident] = ACTIONS(37),
-    [aux_sym_line_comment_token2] = ACTIONS(5),
-    [sym_block_comment] = ACTIONS(7),
-  },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 14,
+  [0] = 17,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(19), 1,
+      anon_sym_LPAREN,
+    ACTIONS(23), 1,
+      anon_sym_LBRACK,
+    ACTIONS(25), 1,
+      anon_sym_STAR,
+    ACTIONS(27), 1,
+      anon_sym_POUND,
+    ACTIONS(29), 1,
+      aux_sym_int_token2,
+    ACTIONS(31), 1,
+      sym_float,
+    ACTIONS(33), 1,
+      sym_string,
+    STATE(5), 1,
+      sym_line_comment,
+    STATE(15), 1,
+      sym_reg,
+    STATE(25), 1,
+      sym_int,
+    STATE(55), 1,
+      sym__expr,
+    ACTIONS(37), 2,
+      sym_meta_ident,
+      sym__ident,
+    STATE(52), 2,
+      sym_ptr,
+      sym_ident,
+    ACTIONS(35), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    ACTIONS(21), 4,
+      anon_sym_byte,
+      anon_sym_word,
+      anon_sym_dword,
+      anon_sym_qword,
+  [59] = 14,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -1499,9 +1537,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_line_comment,
     STATE(15), 1,
       sym_reg,
-    STATE(30), 1,
+    STATE(29), 1,
       sym_int,
-    STATE(57), 1,
+    STATE(63), 1,
       sym_ident,
     ACTIONS(37), 2,
       sym_meta_ident,
@@ -1513,7 +1551,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-  [47] = 9,
+  [106] = 9,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -1529,14 +1567,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(73), 2,
+    STATE(77), 2,
       sym_int,
       sym_ident,
     ACTIONS(35), 3,
       sym_word,
       sym__reg,
       sym_address,
-  [79] = 9,
+  [138] = 9,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -1552,14 +1590,14 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(68), 2,
+    STATE(71), 2,
       sym_int,
       sym_ident,
     ACTIONS(35), 3,
       sym_word,
       sym__reg,
       sym_address,
-  [111] = 11,
+  [170] = 11,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1578,13 +1616,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_line_comment,
     STATE(16), 1,
       aux_sym_program_repeat1,
-    STATE(55), 1,
+    STATE(61), 1,
       sym__item,
     STATE(59), 3,
       sym_meta,
       sym_label,
       sym_instruction,
-  [147] = 11,
+  [206] = 11,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1603,13 +1641,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_line_comment,
     STATE(16), 1,
       aux_sym_program_repeat1,
-    STATE(55), 1,
+    STATE(61), 1,
       sym__item,
     STATE(59), 3,
       sym_meta,
       sym_label,
       sym_instruction,
-  [183] = 10,
+  [242] = 10,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1626,13 +1664,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym_line_comment,
     STATE(16), 1,
       aux_sym_program_repeat1,
-    STATE(55), 1,
+    STATE(61), 1,
       sym__item,
     STATE(59), 3,
       sym_meta,
       sym_label,
       sym_instruction,
-  [216] = 9,
+  [275] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1645,7 +1683,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_line_comment,
     STATE(15), 1,
       sym_reg,
-    STATE(61), 1,
+    STATE(68), 1,
       sym_ident,
     ACTIONS(35), 2,
       sym_word,
@@ -1653,7 +1691,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
-  [246] = 9,
+  [305] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1666,7 +1704,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_line_comment,
     STATE(15), 1,
       sym_reg,
-    STATE(67), 1,
+    STATE(72), 1,
       sym_ident,
     ACTIONS(35), 2,
       sym_word,
@@ -1674,7 +1712,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(37), 2,
       sym_meta_ident,
       sym__ident,
-  [276] = 5,
+  [335] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1691,7 +1729,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_RBRACK,
-  [298] = 5,
+  [357] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1706,7 +1744,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_RPAREN,
       anon_sym_RBRACK,
-  [318] = 6,
+  [377] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1722,7 +1760,7 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
       sym_word,
       sym_meta_ident,
-  [340] = 5,
+  [399] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1737,7 +1775,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_LPAREN,
       anon_sym_RBRACK,
-  [360] = 5,
+  [419] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1752,23 +1790,23 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_COMMA,
       anon_sym_LPAREN,
       anon_sym_RBRACK,
-  [380] = 7,
+  [439] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(72), 1,
+    ACTIONS(74), 1,
       anon_sym_COMMA,
     STATE(19), 1,
       sym_line_comment,
-    STATE(27), 1,
-      aux_sym_instruction_repeat1,
-    ACTIONS(41), 2,
+    STATE(33), 1,
+      aux_sym_meta_repeat2,
+    ACTIONS(72), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [403] = 6,
+  [462] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1777,29 +1815,29 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(76), 1,
       anon_sym_COMMA,
-    ACTIONS(74), 2,
+    STATE(20), 1,
+      sym_line_comment,
+    STATE(26), 1,
+      aux_sym_meta_repeat3,
+    ACTIONS(72), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    STATE(20), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat3,
-  [424] = 7,
+  [485] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(35), 1,
-      sym__reg,
+    ACTIONS(80), 1,
+      anon_sym_BANG,
     STATE(21), 1,
       sym_line_comment,
-    STATE(43), 1,
-      sym_reg,
-    ACTIONS(57), 2,
-      sym_word,
-      sym_address,
-  [447] = 8,
+    ACTIONS(78), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [506] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1808,139 +1846,124 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(53), 1,
       anon_sym_LF,
-    ACTIONS(79), 1,
+    ACTIONS(82), 1,
       ts_builtin_sym_end,
     STATE(10), 1,
       aux_sym_program_repeat1,
     STATE(22), 1,
       sym_line_comment,
-    STATE(33), 1,
+    STATE(32), 1,
       aux_sym_program_repeat2,
-  [472] = 6,
+  [531] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(83), 1,
+    ACTIONS(86), 1,
       anon_sym_COMMA,
-    ACTIONS(81), 2,
+    ACTIONS(84), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
     STATE(23), 2,
       sym_line_comment,
       aux_sym_meta_repeat1,
-  [493] = 6,
+  [552] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(88), 1,
+    ACTIONS(91), 1,
       anon_sym_COMMA,
-    ACTIONS(86), 2,
+    STATE(24), 1,
+      sym_line_comment,
+    STATE(37), 1,
+      aux_sym_instruction_repeat1,
+    ACTIONS(89), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    STATE(24), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat2,
-  [514] = 7,
+  [575] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(93), 1,
-      anon_sym_COMMA,
-    STATE(19), 1,
-      aux_sym_instruction_repeat1,
+    ACTIONS(95), 1,
+      anon_sym_LPAREN,
     STATE(25), 1,
       sym_line_comment,
-    ACTIONS(91), 2,
+    ACTIONS(93), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [537] = 6,
+      anon_sym_COMMA,
+  [596] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(97), 1,
-      anon_sym_LPAREN,
-    STATE(26), 1,
+    ACTIONS(99), 1,
+      anon_sym_COMMA,
+    ACTIONS(97), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    STATE(26), 2,
       sym_line_comment,
-    ACTIONS(95), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [558] = 6,
+      aux_sym_meta_repeat3,
+  [617] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(101), 1,
+    ACTIONS(74), 1,
       anon_sym_COMMA,
-    ACTIONS(99), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(27), 2,
+    STATE(19), 1,
+      aux_sym_meta_repeat2,
+    STATE(27), 1,
       sym_line_comment,
-      aux_sym_instruction_repeat1,
-  [579] = 7,
+    ACTIONS(102), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [640] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(106), 1,
+    ACTIONS(76), 1,
       anon_sym_COMMA,
+    STATE(20), 1,
+      aux_sym_meta_repeat3,
     STATE(28), 1,
       sym_line_comment,
-    STATE(39), 1,
-      aux_sym_meta_repeat2,
-    ACTIONS(104), 2,
+    ACTIONS(102), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [602] = 7,
+  [663] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(108), 1,
+    ACTIONS(104), 1,
       anon_sym_COMMA,
     STATE(29), 1,
       sym_line_comment,
-    STATE(37), 1,
-      aux_sym_meta_repeat3,
-    ACTIONS(104), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [625] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(110), 1,
-      anon_sym_COMMA,
-    STATE(30), 1,
-      sym_line_comment,
-    STATE(36), 1,
+    STATE(41), 1,
       aux_sym_meta_repeat1,
-    ACTIONS(104), 2,
+    ACTIONS(102), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [648] = 7,
+  [686] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1949,28 +1972,28 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(35), 1,
       sym__reg,
-    STATE(31), 1,
+    STATE(30), 1,
       sym_line_comment,
-    STATE(46), 1,
+    STATE(35), 1,
       sym_reg,
     ACTIONS(57), 2,
       sym_word,
       sym_address,
-  [671] = 5,
+  [709] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(32), 1,
+    STATE(31), 1,
       sym_line_comment,
-    ACTIONS(112), 4,
+    ACTIONS(106), 4,
       ts_builtin_sym_end,
       anon_sym_LF,
       sym_word,
       sym_meta_ident,
-  [690] = 8,
+  [728] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -1983,43 +2006,11 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
     STATE(9), 1,
       aux_sym_program_repeat1,
-    STATE(33), 1,
+    STATE(32), 1,
       sym_line_comment,
-    STATE(34), 1,
+    STATE(42), 1,
       aux_sym_program_repeat2,
-  [715] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(114), 1,
-      ts_builtin_sym_end,
-    ACTIONS(116), 1,
-      anon_sym_LF,
-    STATE(11), 1,
-      aux_sym_program_repeat1,
-    STATE(34), 2,
-      sym_line_comment,
-      aux_sym_program_repeat2,
-  [738] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(35), 1,
-      sym__reg,
-    STATE(35), 1,
-      sym_line_comment,
-    STATE(60), 1,
-      sym_reg,
-    ACTIONS(57), 2,
-      sym_word,
-      sym_address,
-  [761] = 7,
+  [753] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2028,30 +2019,75 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(110), 1,
       anon_sym_COMMA,
-    STATE(23), 1,
-      aux_sym_meta_repeat1,
-    STATE(36), 1,
-      sym_line_comment,
-    ACTIONS(119), 2,
+    ACTIONS(108), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [784] = 7,
+    STATE(33), 2,
+      sym_line_comment,
+      aux_sym_meta_repeat2,
+  [774] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(108), 1,
+    ACTIONS(115), 1,
       anon_sym_COMMA,
-    STATE(20), 1,
-      aux_sym_meta_repeat3,
-    STATE(37), 1,
-      sym_line_comment,
-    ACTIONS(119), 2,
+    ACTIONS(113), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [807] = 7,
+    STATE(34), 2,
+      sym_line_comment,
+      aux_sym_instruction_repeat1,
+  [795] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(118), 1,
+      anon_sym_COMMA,
+    ACTIONS(122), 1,
+      anon_sym_RBRACK,
+    STATE(35), 1,
+      sym_line_comment,
+    ACTIONS(120), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [818] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(126), 1,
+      anon_sym_BANG,
+    STATE(36), 1,
+      sym_line_comment,
+    ACTIONS(124), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [839] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(128), 1,
+      anon_sym_COMMA,
+    STATE(34), 1,
+      aux_sym_instruction_repeat1,
+    STATE(37), 1,
+      sym_line_comment,
+    ACTIONS(41), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [862] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2062,81 +2098,89 @@ static const uint16_t ts_small_parse_table[] = {
       sym__reg,
     STATE(38), 1,
       sym_line_comment,
+    STATE(75), 1,
+      sym_reg,
+    ACTIONS(57), 2,
+      sym_word,
+      sym_address,
+  [885] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(35), 1,
+      sym__reg,
+    STATE(39), 1,
+      sym_line_comment,
+    STATE(50), 1,
+      sym_reg,
+    ACTIONS(57), 2,
+      sym_word,
+      sym_address,
+  [908] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(35), 1,
+      sym__reg,
+    STATE(40), 1,
+      sym_line_comment,
     STATE(64), 1,
       sym_reg,
     ACTIONS(57), 2,
       sym_word,
       sym_address,
-  [830] = 7,
+  [931] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(106), 1,
+    ACTIONS(104), 1,
       anon_sym_COMMA,
-    STATE(24), 1,
-      aux_sym_meta_repeat2,
-    STATE(39), 1,
-      sym_line_comment,
-    ACTIONS(119), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [853] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(40), 1,
-      sym_line_comment,
-    ACTIONS(95), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [871] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
+    STATE(23), 1,
+      aux_sym_meta_repeat1,
     STATE(41), 1,
       sym_line_comment,
-    ACTIONS(121), 3,
+    ACTIONS(72), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-  [889] = 5,
+  [954] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(42), 1,
+    ACTIONS(130), 1,
+      ts_builtin_sym_end,
+    ACTIONS(132), 1,
+      anon_sym_LF,
+    STATE(11), 1,
+      aux_sym_program_repeat1,
+    STATE(42), 2,
       sym_line_comment,
-    ACTIONS(123), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [907] = 6,
+      aux_sym_program_repeat2,
+  [977] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(127), 1,
-      anon_sym_RBRACK,
     STATE(43), 1,
       sym_line_comment,
-    ACTIONS(125), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [927] = 5,
+    ACTIONS(97), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [995] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2145,39 +2189,37 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(44), 1,
       sym_line_comment,
-    ACTIONS(129), 3,
+    ACTIONS(108), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [945] = 6,
+  [1013] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(133), 1,
-      anon_sym_LPAREN,
     STATE(45), 1,
       sym_line_comment,
-    ACTIONS(131), 2,
+    ACTIONS(135), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [965] = 6,
+      anon_sym_COMMA,
+  [1031] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(137), 1,
-      anon_sym_RBRACK,
     STATE(46), 1,
       sym_line_comment,
-    ACTIONS(135), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [985] = 5,
+    ACTIONS(137), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [1049] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2186,11 +2228,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(47), 1,
       sym_line_comment,
-    ACTIONS(139), 3,
+    ACTIONS(78), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1003] = 5,
+  [1067] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2199,24 +2241,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(48), 1,
       sym_line_comment,
-    ACTIONS(81), 3,
+    ACTIONS(139), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1021] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(49), 1,
-      sym_line_comment,
-    ACTIONS(99), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [1039] = 6,
+  [1085] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2225,12 +2254,26 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(143), 1,
       anon_sym_LPAREN,
-    STATE(50), 1,
+    STATE(49), 1,
       sym_line_comment,
     ACTIONS(141), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1059] = 5,
+  [1105] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(147), 1,
+      anon_sym_RBRACK,
+    STATE(50), 1,
+      sym_line_comment,
+    ACTIONS(145), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [1125] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2239,11 +2282,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(51), 1,
       sym_line_comment,
-    ACTIONS(74), 3,
+    ACTIONS(124), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1077] = 5,
+  [1143] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2252,36 +2295,38 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(52), 1,
       sym_line_comment,
-    ACTIONS(86), 3,
+    ACTIONS(93), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [1095] = 5,
+  [1161] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(151), 1,
+      anon_sym_LPAREN,
     STATE(53), 1,
       sym_line_comment,
-    ACTIONS(145), 2,
+    ACTIONS(149), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1112] = 6,
+  [1181] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(27), 1,
-      anon_sym_POUND,
-    ACTIONS(147), 1,
-      aux_sym_int_token2,
-    STATE(48), 1,
-      sym_int,
     STATE(54), 1,
       sym_line_comment,
-  [1131] = 5,
+    ACTIONS(84), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [1199] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2290,22 +2335,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(55), 1,
       sym_line_comment,
-    ACTIONS(114), 2,
+    ACTIONS(113), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1148] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
+      anon_sym_COMMA,
+  [1217] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(27), 1,
+      anon_sym_POUND,
+    ACTIONS(153), 1,
+      aux_sym_int_token2,
     STATE(56), 1,
       sym_line_comment,
-    ACTIONS(149), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1165] = 5,
+    STATE(70), 1,
+      sym_int,
+  [1236] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2314,23 +2361,23 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(57), 1,
       sym_line_comment,
-    ACTIONS(104), 2,
+    ACTIONS(155), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1182] = 6,
+  [1253] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(27), 1,
       anon_sym_POUND,
-    ACTIONS(147), 1,
+    ACTIONS(153), 1,
       aux_sym_int_token2,
     STATE(58), 1,
       sym_line_comment,
-    STATE(68), 1,
+    STATE(71), 1,
       sym_int,
-  [1201] = 5,
+  [1272] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2339,43 +2386,70 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(59), 1,
       sym_line_comment,
-    ACTIONS(151), 2,
+    ACTIONS(157), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1218] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
+  [1289] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(127), 1,
-      anon_sym_RPAREN,
+    ACTIONS(27), 1,
+      anon_sym_POUND,
+    ACTIONS(153), 1,
+      aux_sym_int_token2,
+    STATE(54), 1,
+      sym_int,
     STATE(60), 1,
       sym_line_comment,
-  [1234] = 5,
+  [1308] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(153), 1,
-      anon_sym_RPAREN,
     STATE(61), 1,
       sym_line_comment,
-  [1250] = 5,
-    ACTIONS(155), 1,
+    ACTIONS(130), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [1325] = 5,
+    ACTIONS(3), 1,
       anon_sym_POUND,
-    ACTIONS(157), 1,
-      aux_sym_line_comment_token1,
-    ACTIONS(159), 1,
+    ACTIONS(5), 1,
       aux_sym_line_comment_token2,
-    ACTIONS(161), 1,
+    ACTIONS(7), 1,
       sym_block_comment,
     STATE(62), 1,
       sym_line_comment,
-  [1266] = 5,
+    ACTIONS(159), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [1342] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(63), 1,
+      sym_line_comment,
+    ACTIONS(102), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [1359] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(161), 1,
+      anon_sym_RPAREN,
+    STATE(64), 1,
+      sym_line_comment,
+  [1375] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2383,10 +2457,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(163), 1,
-      anon_sym_ptr,
-    STATE(63), 1,
+      anon_sym_LBRACK,
+    STATE(65), 1,
       sym_line_comment,
-  [1282] = 5,
+  [1391] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2394,10 +2468,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(165), 1,
-      anon_sym_RPAREN,
-    STATE(64), 1,
+      anon_sym_ptr,
+    STATE(66), 1,
       sym_line_comment,
-  [1298] = 5,
+  [1407] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2405,10 +2479,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(167), 1,
-      aux_sym_int_token1,
-    STATE(65), 1,
+      sym_float,
+    STATE(67), 1,
       sym_line_comment,
-  [1314] = 5,
+  [1423] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2416,10 +2490,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(169), 1,
-      anon_sym_rel,
-    STATE(66), 1,
+      anon_sym_RPAREN,
+    STATE(68), 1,
       sym_line_comment,
-  [1330] = 5,
+  [1439] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2427,21 +2501,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(171), 1,
-      anon_sym_RPAREN,
-    STATE(67), 1,
+      anon_sym_rel,
+    STATE(69), 1,
       sym_line_comment,
-  [1346] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(137), 1,
-      anon_sym_RBRACK,
-    STATE(68), 1,
-      sym_line_comment,
-  [1362] = 5,
+  [1455] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2449,10 +2512,21 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(173), 1,
-      ts_builtin_sym_end,
-    STATE(69), 1,
+      anon_sym_RBRACK,
+    STATE(70), 1,
       sym_line_comment,
-  [1378] = 5,
+  [1471] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(147), 1,
+      anon_sym_RBRACK,
+    STATE(71), 1,
+      sym_line_comment,
+  [1487] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2460,10 +2534,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(175), 1,
-      sym_float,
-    STATE(70), 1,
+      anon_sym_RPAREN,
+    STATE(72), 1,
       sym_line_comment,
-  [1394] = 5,
+  [1503] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2471,223 +2545,269 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(177), 1,
-      anon_sym_LBRACK,
-    STATE(71), 1,
-      sym_line_comment,
-  [1410] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(179), 1,
-      anon_sym_LBRACK,
-    STATE(72), 1,
-      sym_line_comment,
-  [1426] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(181), 1,
-      anon_sym_RBRACK,
+      ts_builtin_sym_end,
     STATE(73), 1,
       sym_line_comment,
-  [1442] = 5,
+  [1519] = 5,
+    ACTIONS(179), 1,
+      anon_sym_POUND,
+    ACTIONS(181), 1,
+      aux_sym_line_comment_token1,
+    ACTIONS(183), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(185), 1,
+      sym_block_comment,
+    STATE(74), 1,
+      sym_line_comment,
+  [1535] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(183), 1,
-      sym_string,
-    STATE(74), 1,
+    ACTIONS(126), 1,
+      anon_sym_RPAREN,
+    STATE(75), 1,
       sym_line_comment,
-  [1458] = 1,
-    ACTIONS(185), 1,
-      ts_builtin_sym_end,
-  [1462] = 1,
+  [1551] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
     ACTIONS(187), 1,
+      aux_sym_int_token1,
+    STATE(76), 1,
+      sym_line_comment,
+  [1567] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(189), 1,
+      anon_sym_RBRACK,
+    STATE(77), 1,
+      sym_line_comment,
+  [1583] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(191), 1,
+      anon_sym_LBRACK,
+    STATE(78), 1,
+      sym_line_comment,
+  [1599] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(193), 1,
+      sym_string,
+    STATE(79), 1,
+      sym_line_comment,
+  [1615] = 1,
+    ACTIONS(195), 1,
+      ts_builtin_sym_end,
+  [1619] = 1,
+    ACTIONS(197), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
-  [SMALL_STATE(6)] = 0,
-  [SMALL_STATE(7)] = 47,
-  [SMALL_STATE(8)] = 79,
-  [SMALL_STATE(9)] = 111,
-  [SMALL_STATE(10)] = 147,
-  [SMALL_STATE(11)] = 183,
-  [SMALL_STATE(12)] = 216,
-  [SMALL_STATE(13)] = 246,
-  [SMALL_STATE(14)] = 276,
-  [SMALL_STATE(15)] = 298,
-  [SMALL_STATE(16)] = 318,
-  [SMALL_STATE(17)] = 340,
-  [SMALL_STATE(18)] = 360,
-  [SMALL_STATE(19)] = 380,
-  [SMALL_STATE(20)] = 403,
-  [SMALL_STATE(21)] = 424,
-  [SMALL_STATE(22)] = 447,
-  [SMALL_STATE(23)] = 472,
-  [SMALL_STATE(24)] = 493,
-  [SMALL_STATE(25)] = 514,
-  [SMALL_STATE(26)] = 537,
-  [SMALL_STATE(27)] = 558,
-  [SMALL_STATE(28)] = 579,
-  [SMALL_STATE(29)] = 602,
-  [SMALL_STATE(30)] = 625,
-  [SMALL_STATE(31)] = 648,
-  [SMALL_STATE(32)] = 671,
-  [SMALL_STATE(33)] = 690,
-  [SMALL_STATE(34)] = 715,
-  [SMALL_STATE(35)] = 738,
-  [SMALL_STATE(36)] = 761,
-  [SMALL_STATE(37)] = 784,
-  [SMALL_STATE(38)] = 807,
-  [SMALL_STATE(39)] = 830,
-  [SMALL_STATE(40)] = 853,
-  [SMALL_STATE(41)] = 871,
-  [SMALL_STATE(42)] = 889,
-  [SMALL_STATE(43)] = 907,
-  [SMALL_STATE(44)] = 927,
-  [SMALL_STATE(45)] = 945,
-  [SMALL_STATE(46)] = 965,
-  [SMALL_STATE(47)] = 985,
-  [SMALL_STATE(48)] = 1003,
-  [SMALL_STATE(49)] = 1021,
-  [SMALL_STATE(50)] = 1039,
-  [SMALL_STATE(51)] = 1059,
-  [SMALL_STATE(52)] = 1077,
-  [SMALL_STATE(53)] = 1095,
-  [SMALL_STATE(54)] = 1112,
-  [SMALL_STATE(55)] = 1131,
-  [SMALL_STATE(56)] = 1148,
-  [SMALL_STATE(57)] = 1165,
-  [SMALL_STATE(58)] = 1182,
-  [SMALL_STATE(59)] = 1201,
-  [SMALL_STATE(60)] = 1218,
-  [SMALL_STATE(61)] = 1234,
-  [SMALL_STATE(62)] = 1250,
-  [SMALL_STATE(63)] = 1266,
-  [SMALL_STATE(64)] = 1282,
-  [SMALL_STATE(65)] = 1298,
-  [SMALL_STATE(66)] = 1314,
-  [SMALL_STATE(67)] = 1330,
-  [SMALL_STATE(68)] = 1346,
-  [SMALL_STATE(69)] = 1362,
-  [SMALL_STATE(70)] = 1378,
-  [SMALL_STATE(71)] = 1394,
-  [SMALL_STATE(72)] = 1410,
-  [SMALL_STATE(73)] = 1426,
-  [SMALL_STATE(74)] = 1442,
-  [SMALL_STATE(75)] = 1458,
-  [SMALL_STATE(76)] = 1462,
+  [SMALL_STATE(5)] = 0,
+  [SMALL_STATE(6)] = 59,
+  [SMALL_STATE(7)] = 106,
+  [SMALL_STATE(8)] = 138,
+  [SMALL_STATE(9)] = 170,
+  [SMALL_STATE(10)] = 206,
+  [SMALL_STATE(11)] = 242,
+  [SMALL_STATE(12)] = 275,
+  [SMALL_STATE(13)] = 305,
+  [SMALL_STATE(14)] = 335,
+  [SMALL_STATE(15)] = 357,
+  [SMALL_STATE(16)] = 377,
+  [SMALL_STATE(17)] = 399,
+  [SMALL_STATE(18)] = 419,
+  [SMALL_STATE(19)] = 439,
+  [SMALL_STATE(20)] = 462,
+  [SMALL_STATE(21)] = 485,
+  [SMALL_STATE(22)] = 506,
+  [SMALL_STATE(23)] = 531,
+  [SMALL_STATE(24)] = 552,
+  [SMALL_STATE(25)] = 575,
+  [SMALL_STATE(26)] = 596,
+  [SMALL_STATE(27)] = 617,
+  [SMALL_STATE(28)] = 640,
+  [SMALL_STATE(29)] = 663,
+  [SMALL_STATE(30)] = 686,
+  [SMALL_STATE(31)] = 709,
+  [SMALL_STATE(32)] = 728,
+  [SMALL_STATE(33)] = 753,
+  [SMALL_STATE(34)] = 774,
+  [SMALL_STATE(35)] = 795,
+  [SMALL_STATE(36)] = 818,
+  [SMALL_STATE(37)] = 839,
+  [SMALL_STATE(38)] = 862,
+  [SMALL_STATE(39)] = 885,
+  [SMALL_STATE(40)] = 908,
+  [SMALL_STATE(41)] = 931,
+  [SMALL_STATE(42)] = 954,
+  [SMALL_STATE(43)] = 977,
+  [SMALL_STATE(44)] = 995,
+  [SMALL_STATE(45)] = 1013,
+  [SMALL_STATE(46)] = 1031,
+  [SMALL_STATE(47)] = 1049,
+  [SMALL_STATE(48)] = 1067,
+  [SMALL_STATE(49)] = 1085,
+  [SMALL_STATE(50)] = 1105,
+  [SMALL_STATE(51)] = 1125,
+  [SMALL_STATE(52)] = 1143,
+  [SMALL_STATE(53)] = 1161,
+  [SMALL_STATE(54)] = 1181,
+  [SMALL_STATE(55)] = 1199,
+  [SMALL_STATE(56)] = 1217,
+  [SMALL_STATE(57)] = 1236,
+  [SMALL_STATE(58)] = 1253,
+  [SMALL_STATE(59)] = 1272,
+  [SMALL_STATE(60)] = 1289,
+  [SMALL_STATE(61)] = 1308,
+  [SMALL_STATE(62)] = 1325,
+  [SMALL_STATE(63)] = 1342,
+  [SMALL_STATE(64)] = 1359,
+  [SMALL_STATE(65)] = 1375,
+  [SMALL_STATE(66)] = 1391,
+  [SMALL_STATE(67)] = 1407,
+  [SMALL_STATE(68)] = 1423,
+  [SMALL_STATE(69)] = 1439,
+  [SMALL_STATE(70)] = 1455,
+  [SMALL_STATE(71)] = 1471,
+  [SMALL_STATE(72)] = 1487,
+  [SMALL_STATE(73)] = 1503,
+  [SMALL_STATE(74)] = 1519,
+  [SMALL_STATE(75)] = 1535,
+  [SMALL_STATE(76)] = 1551,
+  [SMALL_STATE(77)] = 1567,
+  [SMALL_STATE(78)] = 1583,
+  [SMALL_STATE(79)] = 1599,
+  [SMALL_STATE(80)] = 1615,
+  [SMALL_STATE(81)] = 1619,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
   [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 1, .production_id = 1),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(63),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(18),
-  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [19] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [21] = {.entry = {.count = 1, .reusable = false}}, SHIFT(66),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [31] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
   [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
   [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
   [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, .production_id = 1),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, .production_id = 1),
   [43] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 1, .production_id = 1),
-  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [45] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
   [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3),
-  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
   [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2),
   [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
   [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1),
   [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ident, 1),
   [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2),
-  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(32),
-  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 2),
-  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1),
-  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2),
-  [76] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2), SHIFT_REPEAT(74),
-  [79] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2),
-  [83] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2), SHIFT_REPEAT(54),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2),
-  [88] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2), SHIFT_REPEAT(70),
-  [91] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, .production_id = 1),
-  [93] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1),
-  [97] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [99] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2),
-  [101] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2), SHIFT_REPEAT(5),
-  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, .production_id = 1),
-  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1),
-  [114] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2),
-  [116] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2), SHIFT_REPEAT(32),
-  [119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, .production_id = 1),
-  [121] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7),
-  [123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5),
-  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4),
-  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, .production_id = 2),
-  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3),
-  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, .production_id = 2),
-  [151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [155] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [157] = {.entry = {.count = 1, .reusable = false}}, SHIFT(75),
-  [159] = {.entry = {.count = 1, .reusable = false}}, SHIFT(76),
-  [161] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
-  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
-  [173] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [177] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [181] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [185] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2),
-  [187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1),
+  [65] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2), SHIFT_REPEAT(31),
+  [68] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 2),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, .production_id = 1),
+  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5),
+  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1),
+  [84] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2),
+  [86] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2), SHIFT_REPEAT(60),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, .production_id = 1),
+  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [93] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1),
+  [95] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [97] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2),
+  [99] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2), SHIFT_REPEAT(79),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, .production_id = 1),
+  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1),
+  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2),
+  [110] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2), SHIFT_REPEAT(67),
+  [113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2),
+  [115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2), SHIFT_REPEAT(5),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [122] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3),
+  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [130] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2),
+  [132] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2), SHIFT_REPEAT(31),
+  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7),
+  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 6),
+  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, .production_id = 2),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5),
+  [157] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1),
+  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, .production_id = 2),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [165] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [171] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [173] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [175] = {.entry = {.count = 1, .reusable = true}}, SHIFT(62),
+  [177] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [179] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
+  [181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [183] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [185] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2),
+  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-#ifdef _WIN32
+#ifdef TREE_SITTER_HIDE_SYMBOLS
+#define TS_PUBLIC
+#elif defined(_WIN32)
 #define TS_PUBLIC __declspec(dllexport)
 #else
 #define TS_PUBLIC __attribute__((visibility("default")))

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \

--- a/test/corpus/instr_and_reg.test
+++ b/test/corpus/instr_and_reg.test
@@ -64,6 +64,58 @@ mov X10, #1
                 (word)))
         (int)))
 
+
+==========
+Instruction -- Reg arg, reg arg, address pointer with register and negative integer immediate arg, followed by exclmation mark (ARM A64)
+==========
+stp w0, w1, [sp, #-16]!
+---
+(program
+  (instruction
+    (word)
+    (ident
+      (reg
+        (word)))
+    (ident
+      (reg
+        (word)))
+    (ptr
+      (reg
+        (word))
+      (int))))
+
+
+==========
+Instruction -- Reg arg, address pointer with register and integer immediate arg (ARM A64)
+==========
+ldr x8, [sp, #8]
+---
+(program
+  (instruction
+    (word)
+    (ident
+      (reg
+        (word)))
+    (ptr
+      (reg
+        (word))
+      (int))))
+
+==========
+Instruction -- Reg arg, address pointer with register only (ARM A64)
+==========
+ldr x8, [sp]
+---
+(program
+  (instruction
+    (word)
+    (ident
+      (reg
+        (word)))
+    (ptr
+      (reg
+        (word)))))
+
 ==========
 Instruction -- Reg arg, section address arg (ARM A64)
 ==========


### PR DESCRIPTION
Improve support for Arm64 `LDR` and `LDP` instructions which use square brackets for the `SP` memory reference.