### PR TITLE
line comment doesn't show for single instruction

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -45,8 +45,13 @@ module.exports = grammar({
                 ),
             ),
         const: $ => seq('const', field('name', $.word), field('value', $._tc_expr)),
-        instruction: $ => seq(field('kind', $.word), choice(sep(',', $._expr), repeat($._tc_expr))),
-
+        instruction: $ => seq(
+          field('kind', $.word),
+          optional(choice(
+            $._expr,
+            sep(',', $._expr)
+          ))
+        ),
         _expr: $ => choice($.ptr, $.ident, $.int, $.string, $.float),
         ptr: $ =>
             choice(


### PR DESCRIPTION
Fix https://github.com/RubixDev/tree-sitter-asm/issues/12

For file:

```asm
inc %edi #comment2
```

Previous parse:
```
(program [0, 0] - [1, 0]
  (instruction [0, 0] - [0, 18]
    kind: (word [0, 0] - [0, 3])
    (ident [0, 4] - [0, 8]
      (reg [0, 4] - [0, 8]))
    (int [0, 9] - [0, 10])
    (ident [0, 10] - [0, 18]
      (reg [0, 10] - [0, 18]
        (word [0, 10] - [0, 18])))))
```

After this PR:
```
(program [0, 0] - [1, 0]
  (instruction [0, 0] - [0, 8]
    kind: (word [0, 0] - [0, 3])
    (ident [0, 4] - [0, 8]
      (reg [0, 4] - [0, 8])))
  (line_comment [0, 9] - [0, 18]))
```