### PR TITLE
Revert `tree-sitter-wasm-build-tool` to `v0.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ tree-sitter-c2rust = { version = "0.22.6", optional = true }
 
 [build-dependencies]
 cc = "1.0"
-tree-sitter-wasm-build-tool = { version = "0.2.2", optional = true }
+tree-sitter-wasm-build-tool = { version = "0.1.0", optional = true }


### PR DESCRIPTION
I was peeking at your setup here for tree sitter with WASM compatibility and noticed the most recent commit actually broke the WASM build. The `tree-sitter-wasm-build-tool@0.2.x` version made a breaking change that breaks your build script. Reverting it seems to fix for me. I'm not sure what the correct change to the build script is in order to take the upgrade.