### PR TITLE
fix: error in label followed by directive with single integer argument (ARMv7)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -37,7 +37,7 @@ module.exports = grammar({
                 seq(
                     choice($.meta_ident, alias($.word, $.ident), alias($._ident, $.ident)),
                     ':',
-                    optional(seq('(', $.ident, ')')),
+                    optional(choice(seq('(', $.ident, ')'), $.meta)),
                 ),
                 seq(
                     'label',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "asm",
   "rules": {
     "program": {
@@ -220,19 +219,28 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
+                  "type": "CHOICE",
                   "members": [
                     {
-                      "type": "STRING",
-                      "value": "("
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "ident"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "ident"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": ")"
+                      "name": "meta"
                     }
                   ]
                 },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -131,6 +131,10 @@
           "named": true
         },
         {
+          "type": "meta",
+          "named": true
+        },
+        {
           "type": "meta_ident",
           "named": true
         }
@@ -183,7 +187,6 @@
   {
     "type": "program",
     "named": true,
-    "root": true,
     "fields": {},
     "children": {
       "multiple": true,

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,7 +5,7 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 120
+#define STATE_COUNT 123
 #define LARGE_STATE_COUNT 3
 #define SYMBOL_COUNT 59
 #define ALIAS_COUNT 0
@@ -514,31 +514,31 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [20] = 20,
   [21] = 21,
   [22] = 22,
-  [23] = 23,
-  [24] = 7,
-  [25] = 11,
-  [26] = 10,
-  [27] = 8,
-  [28] = 28,
+  [23] = 11,
+  [24] = 8,
+  [25] = 9,
+  [26] = 26,
+  [27] = 27,
+  [28] = 7,
   [29] = 29,
   [30] = 30,
   [31] = 31,
-  [32] = 28,
-  [33] = 33,
+  [32] = 32,
+  [33] = 29,
   [34] = 34,
-  [35] = 34,
-  [36] = 36,
-  [37] = 33,
-  [38] = 30,
-  [39] = 29,
-  [40] = 16,
-  [41] = 41,
-  [42] = 15,
-  [43] = 13,
-  [44] = 14,
-  [45] = 17,
-  [46] = 18,
-  [47] = 47,
+  [35] = 30,
+  [36] = 32,
+  [37] = 34,
+  [38] = 38,
+  [39] = 39,
+  [40] = 31,
+  [41] = 15,
+  [42] = 18,
+  [43] = 12,
+  [44] = 17,
+  [45] = 45,
+  [46] = 13,
+  [47] = 14,
   [48] = 48,
   [49] = 49,
   [50] = 50,
@@ -606,11 +606,14 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [112] = 112,
   [113] = 113,
   [114] = 114,
-  [115] = 115,
+  [115] = 111,
   [116] = 116,
-  [117] = 108,
+  [117] = 117,
   [118] = 118,
   [119] = 119,
+  [120] = 120,
+  [121] = 121,
+  [122] = 122,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -618,645 +621,646 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(28);
+      if (eof) ADVANCE(29);
       ADVANCE_MAP(
-        '\n', 29,
-        '!', 54,
+        '\n', 30,
+        '!', 55,
         '"', 1,
-        '#', 61,
-        '$', 19,
-        '%', 56,
-        '&', 60,
-        '(', 32,
-        ')', 33,
-        '*', 51,
-        '+', 47,
-        ',', 30,
-        '-', 49,
-        '.', 141,
-        '/', 55,
-        '0', 70,
-        ':', 31,
-        ';', 148,
-        '[', 46,
-        ']', 50,
-        '^', 59,
-        'b', 129,
-        'c', 105,
-        'd', 124,
-        'l', 90,
-        'p', 120,
-        'q', 125,
-        'r', 98,
-        'w', 107,
-        '|', 58,
+        '#', 62,
+        '$', 18,
+        '%', 57,
+        '&', 61,
+        '(', 33,
+        ')', 34,
+        '*', 52,
+        '+', 48,
+        ',', 31,
+        '-', 50,
+        '.', 143,
+        '/', 56,
+        '0', 71,
+        ':', 32,
+        ';', 150,
+        '[', 47,
+        ']', 51,
+        '^', 60,
+        'b', 130,
+        'c', 106,
+        'd', 125,
+        'l', 91,
+        'p', 121,
+        'q', 126,
+        'r', 99,
+        'w', 108,
+        '|', 59,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(73);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(74);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(89);
+      if (lookahead == '"') ADVANCE(90);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '#', 61,
-        '$', 20,
-        '-', 7,
-        '/', 10,
-        '0', 80,
-        ';', 148,
-        'p', 16,
-        'r', 13,
+        '#', 62,
+        '$', 19,
+        '-', 6,
+        '/', 9,
+        '0', 81,
+        ';', 150,
+        'p', 15,
+        'r', 12,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(82);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(83);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(61);
+      if (lookahead == '#') ADVANCE(62);
       if (lookahead == '$') ADVANCE(23);
       if (lookahead == '%') ADVANCE(22);
-      if (lookahead == '.') ADVANCE(141);
-      if (lookahead == '/') ADVANCE(10);
-      if (lookahead == ';') ADVANCE(148);
+      if (lookahead == '.') ADVANCE(143);
+      if (lookahead == '/') ADVANCE(9);
+      if (lookahead == ';') ADVANCE(150);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(3);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(61);
-      if (lookahead == '$') ADVANCE(23);
-      if (lookahead == '%') ADVANCE(22);
-      if (lookahead == '/') ADVANCE(10);
-      if (lookahead == ';') ADVANCE(148);
+      if (lookahead == '#') ADVANCE(62);
+      if (lookahead == '$') ADVANCE(20);
+      if (lookahead == '-') ADVANCE(8);
+      if (lookahead == '/') ADVANCE(9);
+      if (lookahead == '0') ADVANCE(64);
+      if (lookahead == ';') ADVANCE(150);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(4);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(137);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          lookahead == ' ') SKIP(5);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(66);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(61);
-      if (lookahead == '$') ADVANCE(21);
-      if (lookahead == '-') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(10);
-      if (lookahead == '0') ADVANCE(63);
-      if (lookahead == ';') ADVANCE(148);
+      if (lookahead == '#') ADVANCE(62);
+      if (lookahead == '/') ADVANCE(9);
+      if (lookahead == ';') ADVANCE(150);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(6);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(65);
+          lookahead == ' ') SKIP(5);
       END_STATE();
     case 6:
-      if (lookahead == '#') ADVANCE(61);
-      if (lookahead == '/') ADVANCE(10);
-      if (lookahead == ';') ADVANCE(148);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') SKIP(6);
+      if (lookahead == '$') ADVANCE(19);
+      if (lookahead == '0') ADVANCE(81);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(83);
       END_STATE();
     case 7:
-      if (lookahead == '$') ADVANCE(20);
-      if (lookahead == '0') ADVANCE(80);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(82);
+      if (lookahead == '$') ADVANCE(19);
+      if (lookahead == '0') ADVANCE(79);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(80);
       END_STATE();
     case 8:
       if (lookahead == '$') ADVANCE(20);
-      if (lookahead == '0') ADVANCE(78);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (lookahead == '0') ADVANCE(64);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(66);
       END_STATE();
     case 9:
-      if (lookahead == '$') ADVANCE(21);
-      if (lookahead == '0') ADVANCE(63);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(65);
+      if (lookahead == '*') ADVANCE(11);
+      if (lookahead == '/') ADVANCE(150);
       END_STATE();
     case 10:
-      if (lookahead == '*') ADVANCE(12);
-      if (lookahead == '/') ADVANCE(148);
+      if (lookahead == '*') ADVANCE(10);
+      if (lookahead == '/') ADVANCE(151);
+      if (lookahead != 0) ADVANCE(11);
       END_STATE();
     case 11:
-      if (lookahead == '*') ADVANCE(11);
-      if (lookahead == '/') ADVANCE(149);
-      if (lookahead != 0) ADVANCE(12);
+      if (lookahead == '*') ADVANCE(10);
+      if (lookahead != 0) ADVANCE(11);
       END_STATE();
     case 12:
-      if (lookahead == '*') ADVANCE(11);
-      if (lookahead != 0) ADVANCE(12);
+      if (lookahead == 'e') ADVANCE(13);
       END_STATE();
     case 13:
-      if (lookahead == 'e') ADVANCE(14);
+      if (lookahead == 'l') ADVANCE(53);
       END_STATE();
     case 14:
-      if (lookahead == 'l') ADVANCE(52);
+      if (lookahead == 'r') ADVANCE(45);
       END_STATE();
     case 15:
-      if (lookahead == 'r') ADVANCE(44);
+      if (lookahead == 't') ADVANCE(14);
       END_STATE();
     case 16:
-      if (lookahead == 't') ADVANCE(15);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(82);
       END_STATE();
     case 17:
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(81);
+          lookahead == '1') ADVANCE(65);
       END_STATE();
     case 18:
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(64);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(84);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(140);
       END_STATE();
     case 19:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(83);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(139);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(85);
       END_STATE();
     case 20:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(67);
       END_STATE();
     case 21:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(66);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
       END_STATE();
     case 22:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
       END_STATE();
     case 23:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(140);
       END_STATE();
     case 24:
-      if (eof) ADVANCE(28);
+      if (eof) ADVANCE(29);
       ADVANCE_MAP(
-        '\n', 29,
+        '\n', 30,
         '"', 1,
-        '#', 61,
-        '$', 19,
+        '#', 62,
+        '$', 18,
         '%', 22,
-        '(', 32,
-        '*', 51,
-        '-', 8,
-        '.', 141,
-        '/', 10,
-        '0', 75,
-        ':', 31,
-        ';', 148,
-        '[', 46,
-        'b', 128,
-        'd', 126,
-        'q', 127,
-        'w', 106,
+        '(', 33,
+        '*', 52,
+        '-', 7,
+        '.', 143,
+        '/', 9,
+        '0', 76,
+        ':', 32,
+        ';', 150,
+        '[', 47,
+        'b', 129,
+        'd', 127,
+        'q', 128,
+        'w', 107,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(24);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(76);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+          lookahead == '_') ADVANCE(136);
       END_STATE();
     case 25:
-      if (eof) ADVANCE(28);
+      if (eof) ADVANCE(29);
       ADVANCE_MAP(
-        '\n', 29,
+        '\n', 30,
         '"', 1,
-        '#', 61,
-        '$', 19,
+        '#', 62,
+        '$', 18,
         '%', 22,
-        '-', 8,
-        '.', 141,
-        '/', 10,
-        '0', 75,
-        ':', 31,
-        ';', 148,
+        '-', 7,
+        '.', 143,
+        '/', 9,
+        '0', 76,
+        ':', 32,
+        ';', 150,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(25);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(76);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+          lookahead == '_') ADVANCE(136);
       END_STATE();
     case 26:
-      if (eof) ADVANCE(28);
+      if (eof) ADVANCE(29);
       ADVANCE_MAP(
-        '\n', 29,
+        '\n', 30,
         '"', 1,
-        '#', 61,
-        '$', 19,
-        '%', 57,
-        '&', 60,
-        '(', 32,
-        '*', 51,
-        '+', 47,
-        ',', 30,
-        '-', 49,
-        '.', 141,
-        '/', 55,
-        '0', 67,
-        ';', 148,
-        '^', 59,
-        '|', 58,
+        '#', 62,
+        '$', 18,
+        '%', 58,
+        '&', 61,
+        '(', 33,
+        '*', 52,
+        '+', 48,
+        ',', 31,
+        '-', 50,
+        '.', 143,
+        '/', 56,
+        '0', 68,
+        ';', 150,
+        '^', 60,
+        '|', 59,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(26);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(68);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(69);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+          lookahead == '_') ADVANCE(136);
       END_STATE();
     case 27:
-      if (eof) ADVANCE(28);
+      if (eof) ADVANCE(29);
       ADVANCE_MAP(
-        '\n', 29,
-        '#', 61,
-        '%', 56,
-        '&', 60,
-        '(', 32,
-        ')', 33,
-        '*', 51,
-        '+', 47,
-        ',', 30,
-        '-', 48,
-        '.', 141,
-        '/', 55,
-        ';', 148,
-        ']', 50,
-        '^', 59,
-        'c', 105,
-        'l', 90,
-        '|', 58,
+        '\n', 30,
+        '#', 62,
+        '$', 23,
+        '%', 22,
+        '(', 33,
+        '.', 21,
+        '/', 9,
+        ';', 150,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (eof) ADVANCE(29);
+      ADVANCE_MAP(
+        '\n', 30,
+        '#', 62,
+        '%', 57,
+        '&', 61,
+        '(', 33,
+        ')', 34,
+        '*', 52,
+        '+', 48,
+        ',', 31,
+        '-', 49,
+        '.', 143,
+        '/', 56,
+        ';', 150,
+        ']', 51,
+        '^', 60,
+        'c', 106,
+        'l', 91,
+        '|', 59,
+      );
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(28);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(anon_sym_LF);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 30:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      ACCEPT_TOKEN(anon_sym_LF);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(anon_sym_COMMA);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
+      ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
     case 34:
-      ACCEPT_TOKEN(anon_sym_label);
-      if (lookahead == '.') ADVANCE(142);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
     case 35:
-      ACCEPT_TOKEN(anon_sym_const);
-      if (lookahead == '.') ADVANCE(142);
+      ACCEPT_TOKEN(anon_sym_label);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+      ACCEPT_TOKEN(anon_sym_const);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+      ACCEPT_TOKEN(anon_sym_byte);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 40:
-      ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+      ACCEPT_TOKEN(anon_sym_word);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+      ACCEPT_TOKEN(anon_sym_dword);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 44:
-      ACCEPT_TOKEN(anon_sym_ptr);
+      ACCEPT_TOKEN(anon_sym_qword);
+      if (lookahead == '.') ADVANCE(144);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(anon_sym_ptr);
-      if (lookahead == '.') ADVANCE(142);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(anon_sym_ptr);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 47:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(anon_sym_DASH);
-      if (lookahead == '$') ADVANCE(20);
-      if (lookahead == '0') ADVANCE(80);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(82);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (lookahead == '$') ADVANCE(19);
+      if (lookahead == '0') ADVANCE(81);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(83);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 52:
-      ACCEPT_TOKEN(anon_sym_rel);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(anon_sym_rel);
-      if (lookahead == '.') ADVANCE(142);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(anon_sym_rel);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(anon_sym_BANG);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(12);
-      if (lookahead == '/') ADVANCE(148);
+      ACCEPT_TOKEN(anon_sym_BANG);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(11);
+      if (lookahead == '/') ADVANCE(150);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(anon_sym_PERCENT);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
       END_STATE();
     case 59:
-      ACCEPT_TOKEN(anon_sym_CARET);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(anon_sym_AMP);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(anon_sym_POUND);
+      ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(anon_sym_POUND);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(147);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(aux_sym_int_token1);
-      if (lookahead == 'b') ADVANCE(18);
-      if (lookahead == 'x') ADVANCE(21);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(65);
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(149);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(aux_sym_int_token1);
-      if (lookahead == '0' ||
-          lookahead == '1' ||
-          lookahead == '_') ADVANCE(64);
+      if (lookahead == 'b') ADVANCE(17);
+      if (lookahead == 'x') ADVANCE(20);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(66);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(aux_sym_int_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '0' ||
+          lookahead == '1' ||
           lookahead == '_') ADVANCE(65);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(aux_sym_int_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(66);
+          lookahead == '_') ADVANCE(66);
       END_STATE();
     case 67:
-      ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == '_') ADVANCE(73);
-      if (lookahead == 'b') ADVANCE(131);
-      if (lookahead == 'x') ADVANCE(132);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(68);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(135);
+      ACCEPT_TOKEN(aux_sym_int_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(67);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == '_') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(68);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(135);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '_') ADVANCE(74);
+      if (lookahead == 'b') ADVANCE(132);
+      if (lookahead == 'x') ADVANCE(133);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == '_') ADVANCE(71);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(69);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(135);
-      if (('2' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '_') ADVANCE(74);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'b') ADVANCE(130);
-      if (lookahead == 'x') ADVANCE(133);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(73);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '_') ADVANCE(72);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(70);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
+      if (('2' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == '0' ||
-          lookahead == '1' ||
-          lookahead == '_') ADVANCE(71);
-      if (('2' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'b') ADVANCE(131);
+      if (lookahead == 'x') ADVANCE(134);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_') ADVANCE(74);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(72);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(135);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '0' ||
+          lookahead == '1' ||
+          lookahead == '_') ADVANCE(72);
+      if (('2' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_') ADVANCE(75);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(73);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(73);
+      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(74);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          lookahead == '_') ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == '_') ADVANCE(77);
-      if (lookahead == 'b') ADVANCE(131);
-      if (lookahead == 'x') ADVANCE(132);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(76);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(135);
+      if (lookahead == '.') ADVANCE(144);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(85);
-      if (lookahead == '_') ADVANCE(77);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(76);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(135);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (lookahead == '.') ADVANCE(86);
+      if (lookahead == '_') ADVANCE(78);
+      if (lookahead == 'b') ADVANCE(132);
+      if (lookahead == 'x') ADVANCE(133);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(85);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(77);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (lookahead == '.') ADVANCE(86);
+      if (lookahead == '_') ADVANCE(78);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(aux_sym_int_token2);
       if (lookahead == '.') ADVANCE(86);
-      if (lookahead == 'b') ADVANCE(17);
-      if (lookahead == 'x') ADVANCE(20);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(79);
+          lookahead == '_') ADVANCE(78);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(86);
+      if (lookahead == '.') ADVANCE(87);
+      if (lookahead == 'b') ADVANCE(16);
+      if (lookahead == 'x') ADVANCE(19);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(79);
+          lookahead == '_') ADVANCE(80);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == 'b') ADVANCE(17);
-      if (lookahead == 'x') ADVANCE(20);
+      if (lookahead == '.') ADVANCE(87);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(82);
+          lookahead == '_') ADVANCE(80);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '0' ||
-          lookahead == '1' ||
-          lookahead == '_') ADVANCE(81);
+      if (lookahead == 'b') ADVANCE(16);
+      if (lookahead == 'x') ADVANCE(19);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(83);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '0' ||
+          lookahead == '1' ||
           lookahead == '_') ADVANCE(82);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(aux_sym_int_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(83);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(139);
+          lookahead == '_') ADVANCE(83);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(aux_sym_int_token2);
@@ -1264,544 +1268,558 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(84);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(140);
       END_STATE();
     case 85:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(87);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+      ACCEPT_TOKEN(aux_sym_int_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(85);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(88);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
       END_STATE();
     case 87:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(87);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(89);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(88);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
       END_STATE();
     case 89:
-      ACCEPT_TOKEN(sym_string);
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(89);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'a') ADVANCE(91);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      ACCEPT_TOKEN(sym_string);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'b') ADVANCE(101);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'a') ADVANCE(92);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'd') ADVANCE(39);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'b') ADVANCE(102);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'd') ADVANCE(41);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(40);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'd') ADVANCE(43);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(42);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'd') ADVANCE(38);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'd') ADVANCE(40);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'd') ADVANCE(42);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'e') ADVANCE(102);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(44);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(41);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'd') ADVANCE(43);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'e') ADVANCE(37);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'e') ADVANCE(36);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == 'e') ADVANCE(103);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'e') ADVANCE(38);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 101:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'e') ADVANCE(37);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'l') ADVANCE(53);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'e') ADVANCE(104);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'l') ADVANCE(34);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'l') ADVANCE(54);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'n') ADVANCE(119);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'l') ADVANCE(35);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'o') ADVANCE(104);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'n') ADVANCE(120);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'o') ADVANCE(114);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'o') ADVANCE(113);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(105);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(115);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'o') ADVANCE(115);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(114);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'o') ADVANCE(117);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(116);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'o') ADVANCE(116);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == 'o') ADVANCE(118);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 112:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'r') ADVANCE(45);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(117);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'o') ADVANCE(119);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'r') ADVANCE(92);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'r') ADVANCE(46);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'r') ADVANCE(95);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 115:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == 'r') ADVANCE(93);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'r') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'r') ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 117:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == 'r') ADVANCE(94);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'r') ADVANCE(97);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'r') ADVANCE(97);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 119:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 's') ADVANCE(121);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'r') ADVANCE(95);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 119:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'r') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 't') ADVANCE(112);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 's') ADVANCE(122);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 't') ADVANCE(35);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 't') ADVANCE(113);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 't') ADVANCE(100);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 't') ADVANCE(99);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 't') ADVANCE(36);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 't') ADVANCE(101);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'w') ADVANCE(108);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 't') ADVANCE(100);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == 'w') ADVANCE(109);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == 'w') ADVANCE(110);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'w') ADVANCE(111);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'y') ADVANCE(122);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 129:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == 'y') ADVANCE(123);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'w') ADVANCE(111);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'w') ADVANCE(112);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'y') ADVANCE(123);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(71);
-      if (('2' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == 'y') ADVANCE(124);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(69);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+          lookahead == '1') ADVANCE(72);
       if (('2' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(74);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(72);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(70);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
+      if (('2' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(75);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(74);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(73);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          lookahead == '_') ADVANCE(136);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(135);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(142);
+      if (lookahead == '.') ADVANCE(144);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym_word);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(137);
+      if (lookahead == '.') ADVANCE(144);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym_word);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 138:
-      ACCEPT_TOKEN(sym__reg);
+      ACCEPT_TOKEN(sym_word);
       if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 139:
+      ACCEPT_TOKEN(sym__reg);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
+      END_STATE();
+    case 140:
       ACCEPT_TOKEN(sym_address);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
-      END_STATE();
-    case 140:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(140);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(142);
       END_STATE();
     case 141:
-      ACCEPT_TOKEN(sym__ident);
+      ACCEPT_TOKEN(sym_meta_ident);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(140);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(142);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(144);
       END_STATE();
     case 142:
+      ACCEPT_TOKEN(sym_meta_ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(sym__ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(144);
+      END_STATE();
+    case 144:
       ACCEPT_TOKEN(sym__ident);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
-      END_STATE();
-    case 143:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead == '*') ADVANCE(143);
-      if (lookahead == '/') ADVANCE(147);
-      if (lookahead != 0) ADVANCE(144);
-      END_STATE();
-    case 144:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(12);
-      if (lookahead == '*') ADVANCE(143);
-      if (lookahead != 0) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '#') ADVANCE(62);
-      if (lookahead == '/') ADVANCE(146);
-      if (lookahead == ';') ADVANCE(147);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(145);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(147);
+      if (lookahead == '\n') ADVANCE(11);
+      if (lookahead == '*') ADVANCE(145);
+      if (lookahead == '/') ADVANCE(149);
+      if (lookahead != 0) ADVANCE(146);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '*') ADVANCE(144);
-      if (lookahead == '/') ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(147);
+      if (lookahead == '\n') ADVANCE(11);
+      if (lookahead == '*') ADVANCE(145);
+      if (lookahead != 0) ADVANCE(146);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '#') ADVANCE(63);
+      if (lookahead == '/') ADVANCE(148);
+      if (lookahead == ';') ADVANCE(149);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(147);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(147);
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(149);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '*') ADVANCE(146);
+      if (lookahead == '/') ADVANCE(149);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(148);
+          lookahead != '\n') ADVANCE(149);
       END_STATE();
     case 149:
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(149);
+      END_STATE();
+    case 150:
+      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(150);
+      END_STATE();
+    case 151:
       ACCEPT_TOKEN(sym_block_comment);
       END_STATE();
     default:
@@ -1811,7 +1829,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 27},
+  [1] = {.lex_state = 28},
   [2] = {.lex_state = 24},
   [3] = {.lex_state = 24},
   [4] = {.lex_state = 24},
@@ -1832,13 +1850,13 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [19] = {.lex_state = 26},
   [20] = {.lex_state = 26},
   [21] = {.lex_state = 25},
-  [22] = {.lex_state = 27},
-  [23] = {.lex_state = 27},
-  [24] = {.lex_state = 27},
-  [25] = {.lex_state = 27},
-  [26] = {.lex_state = 27},
-  [27] = {.lex_state = 27},
-  [28] = {.lex_state = 26},
+  [22] = {.lex_state = 28},
+  [23] = {.lex_state = 28},
+  [24] = {.lex_state = 28},
+  [25] = {.lex_state = 28},
+  [26] = {.lex_state = 25},
+  [27] = {.lex_state = 28},
+  [28] = {.lex_state = 28},
   [29] = {.lex_state = 26},
   [30] = {.lex_state = 26},
   [31] = {.lex_state = 26},
@@ -1846,90 +1864,93 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [33] = {.lex_state = 26},
   [34] = {.lex_state = 26},
   [35] = {.lex_state = 26},
-  [36] = {.lex_state = 27},
+  [36] = {.lex_state = 26},
   [37] = {.lex_state = 26},
-  [38] = {.lex_state = 26},
+  [38] = {.lex_state = 28},
   [39] = {.lex_state = 26},
-  [40] = {.lex_state = 27},
-  [41] = {.lex_state = 27},
-  [42] = {.lex_state = 27},
-  [43] = {.lex_state = 27},
-  [44] = {.lex_state = 27},
-  [45] = {.lex_state = 27},
-  [46] = {.lex_state = 27},
-  [47] = {.lex_state = 26},
+  [40] = {.lex_state = 26},
+  [41] = {.lex_state = 28},
+  [42] = {.lex_state = 28},
+  [43] = {.lex_state = 28},
+  [44] = {.lex_state = 28},
+  [45] = {.lex_state = 28},
+  [46] = {.lex_state = 28},
+  [47] = {.lex_state = 28},
   [48] = {.lex_state = 26},
-  [49] = {.lex_state = 27},
-  [50] = {.lex_state = 27},
+  [49] = {.lex_state = 26},
+  [50] = {.lex_state = 28},
   [51] = {.lex_state = 3},
-  [52] = {.lex_state = 3},
-  [53] = {.lex_state = 0},
-  [54] = {.lex_state = 0},
-  [55] = {.lex_state = 0},
+  [52] = {.lex_state = 28},
+  [53] = {.lex_state = 3},
+  [54] = {.lex_state = 27},
+  [55] = {.lex_state = 27},
   [56] = {.lex_state = 0},
-  [57] = {.lex_state = 0},
-  [58] = {.lex_state = 4},
+  [57] = {.lex_state = 27},
+  [58] = {.lex_state = 27},
   [59] = {.lex_state = 0},
-  [60] = {.lex_state = 4},
+  [60] = {.lex_state = 0},
   [61] = {.lex_state = 0},
   [62] = {.lex_state = 0},
   [63] = {.lex_state = 0},
-  [64] = {.lex_state = 4},
-  [65] = {.lex_state = 0},
+  [64] = {.lex_state = 27},
+  [65] = {.lex_state = 27},
   [66] = {.lex_state = 0},
   [67] = {.lex_state = 0},
-  [68] = {.lex_state = 27},
+  [68] = {.lex_state = 0},
   [69] = {.lex_state = 0},
   [70] = {.lex_state = 0},
   [71] = {.lex_state = 0},
   [72] = {.lex_state = 0},
   [73] = {.lex_state = 0},
   [74] = {.lex_state = 0},
-  [75] = {.lex_state = 4},
+  [75] = {.lex_state = 0},
   [76] = {.lex_state = 0},
-  [77] = {.lex_state = 0},
+  [77] = {.lex_state = 28},
   [78] = {.lex_state = 0},
   [79] = {.lex_state = 0},
-  [80] = {.lex_state = 0},
+  [80] = {.lex_state = 28},
   [81] = {.lex_state = 0},
-  [82] = {.lex_state = 27},
+  [82] = {.lex_state = 0},
   [83] = {.lex_state = 0},
   [84] = {.lex_state = 0},
   [85] = {.lex_state = 0},
   [86] = {.lex_state = 0},
   [87] = {.lex_state = 0},
   [88] = {.lex_state = 0},
-  [89] = {.lex_state = 2},
+  [89] = {.lex_state = 0},
   [90] = {.lex_state = 0},
   [91] = {.lex_state = 0},
   [92] = {.lex_state = 0},
-  [93] = {.lex_state = 2},
-  [94] = {.lex_state = 0},
+  [93] = {.lex_state = 0},
+  [94] = {.lex_state = 2},
   [95] = {.lex_state = 0},
   [96] = {.lex_state = 0},
-  [97] = {.lex_state = 2},
-  [98] = {.lex_state = 0},
+  [97] = {.lex_state = 0},
+  [98] = {.lex_state = 2},
   [99] = {.lex_state = 0},
-  [100] = {.lex_state = 4},
-  [101] = {.lex_state = 4},
-  [102] = {.lex_state = 0},
+  [100] = {.lex_state = 2},
+  [101] = {.lex_state = 0},
+  [102] = {.lex_state = 2},
   [103] = {.lex_state = 0},
   [104] = {.lex_state = 0},
   [105] = {.lex_state = 0},
   [106] = {.lex_state = 0},
-  [107] = {.lex_state = 2},
-  [108] = {.lex_state = 5},
-  [109] = {.lex_state = 145},
-  [110] = {.lex_state = 24},
-  [111] = {.lex_state = 0},
+  [107] = {.lex_state = 147},
+  [108] = {.lex_state = 0},
+  [109] = {.lex_state = 0},
+  [110] = {.lex_state = 0},
+  [111] = {.lex_state = 4},
   [112] = {.lex_state = 0},
-  [113] = {.lex_state = 0},
-  [114] = {.lex_state = 0},
-  [115] = {.lex_state = 0},
-  [116] = {.lex_state = 2},
-  [117] = {.lex_state = 5},
-  [118] = {(TSStateId)(-1)},
-  [119] = {(TSStateId)(-1)},
+  [113] = {.lex_state = 2},
+  [114] = {.lex_state = 24},
+  [115] = {.lex_state = 4},
+  [116] = {.lex_state = 0},
+  [117] = {.lex_state = 0},
+  [118] = {.lex_state = 0},
+  [119] = {.lex_state = 27},
+  [120] = {.lex_state = 27},
+  [121] = {(TSStateId)(-1)},
+  [122] = {(TSStateId)(-1)},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1971,12 +1992,12 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [1] = {
-    [sym_program] = STATE(113),
-    [sym__item] = STATE(54),
-    [sym_meta] = STATE(90),
-    [sym_label] = STATE(90),
-    [sym_const] = STATE(90),
-    [sym_instruction] = STATE(90),
+    [sym_program] = STATE(117),
+    [sym__item] = STATE(73),
+    [sym_meta] = STATE(92),
+    [sym_label] = STATE(92),
+    [sym_const] = STATE(92),
+    [sym_instruction] = STATE(92),
     [sym_line_comment] = STATE(1),
     [ts_builtin_sym_end] = ACTIONS(9),
     [anon_sym_label] = ACTIONS(11),
@@ -1989,13 +2010,13 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [2] = {
-    [sym__expr] = STATE(70),
-    [sym_ptr] = STATE(78),
-    [sym__tc_expr] = STATE(12),
-    [sym_tc_infix] = STATE(13),
+    [sym__expr] = STATE(67),
+    [sym_ptr] = STATE(81),
+    [sym__tc_expr] = STATE(16),
+    [sym_tc_infix] = STATE(15),
     [sym_int] = STATE(6),
-    [sym_reg] = STATE(10),
-    [sym_ident] = STATE(9),
+    [sym_reg] = STATE(9),
+    [sym_ident] = STATE(10),
     [sym_line_comment] = STATE(2),
     [aux_sym_instruction_repeat2] = STATE(19),
     [ts_builtin_sym_end] = ACTIONS(21),
@@ -2044,11 +2065,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string,
     STATE(3), 1,
       sym_line_comment,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(62), 1,
+    STATE(70), 1,
       sym_int,
-    STATE(87), 1,
+    STATE(83), 1,
       sym__expr,
     ACTIONS(45), 2,
       ts_builtin_sym_end,
@@ -2056,7 +2077,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(55), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(78), 2,
+    STATE(81), 2,
       sym_ptr,
       sym_ident,
     ACTIONS(53), 3,
@@ -2089,11 +2110,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string,
     STATE(4), 1,
       sym_line_comment,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(62), 1,
+    STATE(70), 1,
       sym_int,
-    STATE(87), 1,
+    STATE(83), 1,
       sym__expr,
     ACTIONS(55), 2,
       sym_meta_ident,
@@ -2101,7 +2122,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(57), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    STATE(78), 2,
+    STATE(81), 2,
       sym_ptr,
       sym_ident,
     ACTIONS(53), 3,
@@ -2134,16 +2155,16 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string,
     STATE(5), 1,
       sym_line_comment,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(62), 1,
+    STATE(70), 1,
       sym_int,
-    STATE(87), 1,
+    STATE(83), 1,
       sym__expr,
     ACTIONS(55), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(78), 2,
+    STATE(81), 2,
       sym_ptr,
       sym_ident,
     ACTIONS(53), 3,
@@ -2245,42 +2266,12 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-  [293] = 7,
+  [293] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(62), 1,
-      anon_sym_COMMA,
     STATE(9), 1,
-      sym_line_comment,
-    ACTIONS(59), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(66), 7,
-      anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-      anon_sym_POUND,
-      sym_string,
-    ACTIONS(68), 9,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      aux_sym_int_token2,
-      sym_word,
-      sym__reg,
-      sym_address,
-      sym_meta_ident,
-      sym__ident,
-  [330] = 5,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    STATE(10), 1,
       sym_line_comment,
     ACTIONS(80), 9,
       anon_sym_DASH,
@@ -2303,6 +2294,36 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
+  [326] = 7,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(62), 1,
+      anon_sym_COMMA,
+    STATE(10), 1,
+      sym_line_comment,
+    ACTIONS(59), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    ACTIONS(66), 7,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+      anon_sym_POUND,
+      sym_string,
+    ACTIONS(68), 9,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      aux_sym_int_token2,
+      sym_word,
+      sym__reg,
+      sym_address,
+      sym_meta_ident,
+      sym__ident,
   [363] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
@@ -2331,46 +2352,103 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-  [396] = 12,
+  [396] = 7,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(88), 1,
-      anon_sym_PLUS,
     ACTIONS(90), 1,
-      anon_sym_DASH,
-    ACTIONS(92), 1,
-      anon_sym_STAR,
-    ACTIONS(96), 1,
-      anon_sym_PIPE,
-    ACTIONS(98), 1,
       anon_sym_CARET,
-    ACTIONS(100), 1,
+    ACTIONS(92), 1,
       anon_sym_AMP,
     STATE(12), 1,
       sym_line_comment,
-    ACTIONS(94), 2,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(86), 4,
+    ACTIONS(86), 7,
       ts_builtin_sym_end,
       anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PIPE,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(102), 6,
+    ACTIONS(88), 9,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
       aux_sym_int_token2,
       sym_word,
       sym__reg,
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [442] = 5,
+  [432] = 8,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(90), 1,
+      anon_sym_CARET,
+    ACTIONS(92), 1,
+      anon_sym_AMP,
+    ACTIONS(94), 1,
+      anon_sym_PIPE,
     STATE(13), 1,
+      sym_line_comment,
+    ACTIONS(86), 6,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_POUND,
+      sym_string,
+    ACTIONS(88), 9,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      aux_sym_int_token2,
+      sym_word,
+      sym__reg,
+      sym_address,
+      sym_meta_ident,
+      sym__ident,
+  [470] = 10,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(90), 1,
+      anon_sym_CARET,
+    ACTIONS(92), 1,
+      anon_sym_AMP,
+    ACTIONS(94), 1,
+      anon_sym_PIPE,
+    ACTIONS(96), 1,
+      anon_sym_STAR,
+    STATE(14), 1,
+      sym_line_comment,
+    ACTIONS(98), 2,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(86), 5,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_POUND,
+      sym_string,
+    ACTIONS(88), 7,
+      anon_sym_DASH,
+      aux_sym_int_token2,
+      sym_word,
+      sym__reg,
+      sym_address,
+      sym_meta_ident,
+      sym__ident,
+  [512] = 5,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(15), 1,
       sym_line_comment,
     ACTIONS(66), 9,
       ts_builtin_sym_end,
@@ -2392,115 +2470,58 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [474] = 8,
+  [544] = 12,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(96), 1,
-      anon_sym_PIPE,
-    ACTIONS(98), 1,
+    ACTIONS(90), 1,
       anon_sym_CARET,
-    ACTIONS(100), 1,
-      anon_sym_AMP,
-    STATE(14), 1,
-      sym_line_comment,
-    ACTIONS(104), 6,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_POUND,
-      sym_string,
-    ACTIONS(106), 9,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      aux_sym_int_token2,
-      sym_word,
-      sym__reg,
-      sym_address,
-      sym_meta_ident,
-      sym__ident,
-  [512] = 10,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
     ACTIONS(92), 1,
-      anon_sym_STAR,
-    ACTIONS(96), 1,
-      anon_sym_PIPE,
-    ACTIONS(98), 1,
-      anon_sym_CARET,
-    ACTIONS(100), 1,
       anon_sym_AMP,
-    STATE(15), 1,
-      sym_line_comment,
-    ACTIONS(94), 2,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(104), 5,
-      ts_builtin_sym_end,
-      anon_sym_LF,
+    ACTIONS(94), 1,
+      anon_sym_PIPE,
+    ACTIONS(96), 1,
+      anon_sym_STAR,
+    ACTIONS(102), 1,
       anon_sym_PLUS,
-      anon_sym_POUND,
-      sym_string,
-    ACTIONS(106), 7,
+    ACTIONS(104), 1,
       anon_sym_DASH,
-      aux_sym_int_token2,
-      sym_word,
-      sym__reg,
-      sym_address,
-      sym_meta_ident,
-      sym__ident,
-  [554] = 5,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
     STATE(16), 1,
       sym_line_comment,
-    ACTIONS(104), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-      anon_sym_POUND,
-      sym_string,
-    ACTIONS(106), 9,
-      anon_sym_DASH,
+    ACTIONS(98), 2,
       anon_sym_SLASH,
       anon_sym_PERCENT,
+    ACTIONS(100), 4,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_POUND,
+      sym_string,
+    ACTIONS(106), 6,
       aux_sym_int_token2,
       sym_word,
       sym__reg,
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [586] = 7,
+  [590] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(98), 1,
-      anon_sym_CARET,
-    ACTIONS(100), 1,
-      anon_sym_AMP,
     STATE(17), 1,
       sym_line_comment,
-    ACTIONS(104), 7,
+    ACTIONS(86), 9,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
       anon_sym_STAR,
       anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(106), 9,
+    ACTIONS(88), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2515,11 +2536,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(100), 1,
+    ACTIONS(92), 1,
       anon_sym_AMP,
     STATE(18), 1,
       sym_line_comment,
-    ACTIONS(104), 8,
+    ACTIONS(86), 8,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
@@ -2528,7 +2549,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_CARET,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(106), 9,
+    ACTIONS(88), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2549,9 +2570,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(110), 1,
       sym_string,
-    STATE(10), 1,
+    STATE(9), 1,
       sym_reg,
-    STATE(12), 1,
+    STATE(16), 1,
       sym__tc_expr,
     STATE(19), 1,
       sym_line_comment,
@@ -2567,7 +2588,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(13), 3,
+    STATE(15), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
@@ -2582,9 +2603,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(120), 1,
       sym_string,
-    STATE(10), 1,
+    STATE(9), 1,
       sym_reg,
-    STATE(12), 1,
+    STATE(16), 1,
       sym__tc_expr,
     ACTIONS(112), 2,
       ts_builtin_sym_end,
@@ -2599,7 +2620,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(13), 3,
+    STATE(15), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
@@ -2620,9 +2641,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym_string,
     STATE(21), 1,
       sym_line_comment,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(71), 1,
+    STATE(74), 1,
       sym_int,
     STATE(96), 1,
       sym_ident,
@@ -2659,16 +2680,119 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF,
     STATE(22), 1,
       sym_line_comment,
-    STATE(49), 1,
+    STATE(50), 1,
       aux_sym_program_repeat1,
-    STATE(94), 1,
+    STATE(91), 1,
       sym__item,
-    STATE(90), 4,
+    STATE(92), 4,
       sym_meta,
       sym_label,
       sym_const,
       sym_instruction,
-  [839] = 14,
+  [839] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(84), 1,
+      anon_sym_SLASH,
+    STATE(23), 1,
+      sym_line_comment,
+    ACTIONS(82), 12,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [869] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(76), 1,
+      anon_sym_SLASH,
+    STATE(24), 1,
+      sym_line_comment,
+    ACTIONS(74), 12,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+      anon_sym_LPAREN,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [899] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(80), 1,
+      anon_sym_SLASH,
+    STATE(25), 1,
+      sym_line_comment,
+    ACTIONS(78), 12,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [929] = 13,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(47), 1,
+      anon_sym_POUND,
+    ACTIONS(49), 1,
+      aux_sym_int_token2,
+    ACTIONS(133), 1,
+      sym_float,
+    ACTIONS(135), 1,
+      sym_string,
+    STATE(25), 1,
+      sym_reg,
+    STATE(26), 1,
+      sym_line_comment,
+    STATE(74), 1,
+      sym_int,
+    STATE(96), 1,
+      sym_ident,
+    ACTIONS(55), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(129), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    ACTIONS(53), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+  [973] = 14,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2689,18 +2813,18 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_LF,
     ACTIONS(141), 1,
       ts_builtin_sym_end,
-    STATE(23), 1,
+    STATE(27), 1,
       sym_line_comment,
-    STATE(49), 1,
+    STATE(50), 1,
       aux_sym_program_repeat1,
-    STATE(94), 1,
+    STATE(91), 1,
       sym__item,
-    STATE(90), 4,
+    STATE(92), 4,
       sym_meta,
       sym_label,
       sym_const,
       sym_instruction,
-  [885] = 6,
+  [1019] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2709,7 +2833,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(72), 1,
       anon_sym_SLASH,
-    STATE(24), 1,
+    STATE(28), 1,
       sym_line_comment,
     ACTIONS(70), 12,
       ts_builtin_sym_end,
@@ -2724,79 +2848,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE,
       anon_sym_CARET,
       anon_sym_AMP,
-  [915] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(84), 1,
-      anon_sym_SLASH,
-    STATE(25), 1,
-      sym_line_comment,
-    ACTIONS(82), 12,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [945] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(80), 1,
-      anon_sym_SLASH,
-    STATE(26), 1,
-      sym_line_comment,
-    ACTIONS(78), 12,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [975] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(76), 1,
-      anon_sym_SLASH,
-    STATE(27), 1,
-      sym_line_comment,
-    ACTIONS(74), 12,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-      anon_sym_LPAREN,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [1005] = 11,
+  [1049] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2807,9 +2859,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(143), 1,
       sym_string,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(28), 1,
+    STATE(29), 1,
       sym_line_comment,
     STATE(46), 1,
       sym__tc_expr,
@@ -2820,11 +2872,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(43), 3,
+    STATE(41), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1044] = 11,
+  [1088] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2835,35 +2887,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(110), 1,
       sym_string,
-    STATE(10), 1,
-      sym_reg,
-    STATE(15), 1,
-      sym__tc_expr,
-    STATE(29), 1,
-      sym_line_comment,
-    ACTIONS(43), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(41), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-    STATE(13), 3,
-      sym_tc_infix,
-      sym_int,
-      sym_ident,
-  [1083] = 11,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(33), 1,
-      anon_sym_POUND,
-    ACTIONS(35), 1,
-      aux_sym_int_token2,
-    ACTIONS(110), 1,
-      sym_string,
-    STATE(10), 1,
+    STATE(9), 1,
       sym_reg,
     STATE(17), 1,
       sym__tc_expr,
@@ -2876,39 +2900,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(13), 3,
+    STATE(15), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1122] = 11,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(49), 1,
-      aux_sym_int_token2,
-    ACTIONS(143), 1,
-      sym_string,
-    STATE(26), 1,
-      sym_reg,
-    STATE(31), 1,
-      sym_line_comment,
-    STATE(41), 1,
-      sym__tc_expr,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(53), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-    STATE(43), 3,
-      sym_tc_infix,
-      sym_int,
-      sym_ident,
-  [1161] = 11,
+  [1127] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2919,9 +2915,37 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(110), 1,
       sym_string,
-    STATE(10), 1,
+    STATE(9), 1,
       sym_reg,
     STATE(18), 1,
+      sym__tc_expr,
+    STATE(31), 1,
+      sym_line_comment,
+    ACTIONS(43), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(41), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    STATE(15), 3,
+      sym_tc_infix,
+      sym_int,
+      sym_ident,
+  [1166] = 11,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(33), 1,
+      anon_sym_POUND,
+    ACTIONS(35), 1,
+      aux_sym_int_token2,
+    ACTIONS(110), 1,
+      sym_string,
+    STATE(9), 1,
+      sym_reg,
+    STATE(12), 1,
       sym__tc_expr,
     STATE(32), 1,
       sym_line_comment,
@@ -2932,11 +2956,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(13), 3,
+    STATE(15), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1200] = 11,
+  [1205] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2947,9 +2971,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(110), 1,
       sym_string,
-    STATE(10), 1,
+    STATE(9), 1,
       sym_reg,
-    STATE(14), 1,
+    STATE(13), 1,
       sym__tc_expr,
     STATE(33), 1,
       sym_line_comment,
@@ -2960,11 +2984,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(13), 3,
+    STATE(15), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1239] = 11,
+  [1244] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -2975,9 +2999,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(110), 1,
       sym_string,
-    STATE(10), 1,
+    STATE(9), 1,
       sym_reg,
-    STATE(16), 1,
+    STATE(14), 1,
       sym__tc_expr,
     STATE(34), 1,
       sym_line_comment,
@@ -2988,11 +3012,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(13), 3,
+    STATE(15), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1278] = 11,
+  [1283] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -3003,11 +3027,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(143), 1,
       sym_string,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
     STATE(35), 1,
       sym_line_comment,
-    STATE(40), 1,
+    STATE(44), 1,
       sym__tc_expr,
     ACTIONS(55), 2,
       sym_meta_ident,
@@ -3016,11 +3040,67 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(43), 3,
+    STATE(41), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1317] = 13,
+  [1322] = 11,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(47), 1,
+      anon_sym_POUND,
+    ACTIONS(49), 1,
+      aux_sym_int_token2,
+    ACTIONS(143), 1,
+      sym_string,
+    STATE(25), 1,
+      sym_reg,
+    STATE(36), 1,
+      sym_line_comment,
+    STATE(43), 1,
+      sym__tc_expr,
+    ACTIONS(55), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(53), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    STATE(41), 3,
+      sym_tc_infix,
+      sym_int,
+      sym_ident,
+  [1361] = 11,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(47), 1,
+      anon_sym_POUND,
+    ACTIONS(49), 1,
+      aux_sym_int_token2,
+    ACTIONS(143), 1,
+      sym_string,
+    STATE(25), 1,
+      sym_reg,
+    STATE(37), 1,
+      sym_line_comment,
+    STATE(47), 1,
+      sym__tc_expr,
+    ACTIONS(55), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(53), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    STATE(41), 3,
+      sym_tc_infix,
+      sym_int,
+      sym_ident,
+  [1400] = 13,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3039,18 +3119,18 @@ static const uint16_t ts_small_parse_table[] = {
       sym__ident,
     ACTIONS(139), 1,
       anon_sym_LF,
-    STATE(36), 1,
+    STATE(38), 1,
       sym_line_comment,
-    STATE(49), 1,
+    STATE(50), 1,
       aux_sym_program_repeat1,
-    STATE(94), 1,
+    STATE(91), 1,
       sym__item,
-    STATE(90), 4,
+    STATE(92), 4,
       sym_meta,
       sym_label,
       sym_const,
       sym_instruction,
-  [1360] = 11,
+  [1443] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -3061,37 +3141,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(143), 1,
       sym_string,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(37), 1,
-      sym_line_comment,
-    STATE(44), 1,
-      sym__tc_expr,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(53), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-    STATE(43), 3,
-      sym_tc_infix,
-      sym_int,
-      sym_ident,
-  [1399] = 11,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(49), 1,
-      aux_sym_int_token2,
-    ACTIONS(143), 1,
-      sym_string,
-    STATE(26), 1,
-      sym_reg,
-    STATE(38), 1,
+    STATE(39), 1,
       sym_line_comment,
     STATE(45), 1,
       sym__tc_expr,
@@ -3102,11 +3154,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(43), 3,
+    STATE(41), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1438] = 11,
+  [1482] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -3117,9 +3169,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_int_token2,
     ACTIONS(143), 1,
       sym_string,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(39), 1,
+    STATE(40), 1,
       sym_line_comment,
     STATE(42), 1,
       sym__tc_expr,
@@ -3130,83 +3182,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym__reg,
       sym_address,
-    STATE(43), 3,
+    STATE(41), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1477] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(106), 1,
-      anon_sym_SLASH,
-    STATE(40), 1,
-      sym_line_comment,
-    ACTIONS(104), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [1504] = 11,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(151), 1,
-      anon_sym_SLASH,
-    ACTIONS(153), 1,
-      anon_sym_PIPE,
-    ACTIONS(155), 1,
-      anon_sym_CARET,
-    ACTIONS(157), 1,
-      anon_sym_AMP,
-    STATE(41), 1,
-      sym_line_comment,
-    ACTIONS(145), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(147), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(149), 2,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-  [1541] = 10,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(151), 1,
-      anon_sym_SLASH,
-    ACTIONS(153), 1,
-      anon_sym_PIPE,
-    ACTIONS(155), 1,
-      anon_sym_CARET,
-    ACTIONS(157), 1,
-      anon_sym_AMP,
-    STATE(42), 1,
-      sym_line_comment,
-    ACTIONS(149), 2,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-    ACTIONS(104), 4,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [1576] = 6,
+  [1521] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3215,7 +3195,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(68), 1,
       anon_sym_SLASH,
-    STATE(43), 1,
+    STATE(41), 1,
       sym_line_comment,
     ACTIONS(66), 9,
       ts_builtin_sym_end,
@@ -3227,99 +3207,148 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_PIPE,
       anon_sym_CARET,
       anon_sym_AMP,
-  [1603] = 9,
+  [1548] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(106), 1,
+    ACTIONS(88), 1,
       anon_sym_SLASH,
-    ACTIONS(153), 1,
-      anon_sym_PIPE,
-    ACTIONS(155), 1,
-      anon_sym_CARET,
-    ACTIONS(157), 1,
+    ACTIONS(145), 1,
       anon_sym_AMP,
+    STATE(42), 1,
+      sym_line_comment,
+    ACTIONS(86), 8,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+  [1577] = 8,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(88), 1,
+      anon_sym_SLASH,
+    ACTIONS(145), 1,
+      anon_sym_AMP,
+    ACTIONS(147), 1,
+      anon_sym_CARET,
+    STATE(43), 1,
+      sym_line_comment,
+    ACTIONS(86), 7,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+  [1608] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(88), 1,
+      anon_sym_SLASH,
     STATE(44), 1,
       sym_line_comment,
-    ACTIONS(104), 6,
+    ACTIONS(86), 9,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_STAR,
       anon_sym_PERCENT,
-  [1636] = 8,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [1635] = 11,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(106), 1,
-      anon_sym_SLASH,
-    ACTIONS(155), 1,
-      anon_sym_CARET,
-    ACTIONS(157), 1,
+    ACTIONS(145), 1,
       anon_sym_AMP,
+    ACTIONS(147), 1,
+      anon_sym_CARET,
+    ACTIONS(155), 1,
+      anon_sym_SLASH,
+    ACTIONS(157), 1,
+      anon_sym_PIPE,
     STATE(45), 1,
       sym_line_comment,
-    ACTIONS(104), 7,
+    ACTIONS(149), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
+    ACTIONS(151), 2,
       anon_sym_PLUS,
       anon_sym_DASH,
+    ACTIONS(153), 2,
       anon_sym_STAR,
       anon_sym_PERCENT,
-      anon_sym_PIPE,
-  [1667] = 7,
+  [1672] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(106), 1,
+    ACTIONS(88), 1,
       anon_sym_SLASH,
-    ACTIONS(157), 1,
+    ACTIONS(145), 1,
       anon_sym_AMP,
+    ACTIONS(147), 1,
+      anon_sym_CARET,
+    ACTIONS(157), 1,
+      anon_sym_PIPE,
     STATE(46), 1,
       sym_line_comment,
-    ACTIONS(104), 8,
+    ACTIONS(86), 6,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
       anon_sym_DASH,
       anon_sym_STAR,
       anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-  [1696] = 9,
+  [1705] = 10,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(49), 1,
-      aux_sym_int_token2,
-    STATE(26), 1,
-      sym_reg,
+    ACTIONS(145), 1,
+      anon_sym_AMP,
+    ACTIONS(147), 1,
+      anon_sym_CARET,
+    ACTIONS(155), 1,
+      anon_sym_SLASH,
+    ACTIONS(157), 1,
+      anon_sym_PIPE,
     STATE(47), 1,
       sym_line_comment,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-    STATE(106), 2,
-      sym_int,
-      sym_ident,
-    ACTIONS(53), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-  [1728] = 9,
+    ACTIONS(153), 2,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+    ACTIONS(86), 4,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [1740] = 9,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
@@ -3328,21 +3357,44 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_POUND,
     ACTIONS(49), 1,
       aux_sym_int_token2,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
     STATE(48), 1,
       sym_line_comment,
     ACTIONS(55), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(99), 2,
+    STATE(104), 2,
       sym_int,
       sym_ident,
     ACTIONS(53), 3,
       sym_word,
       sym__reg,
       sym_address,
-  [1760] = 7,
+  [1772] = 9,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(47), 1,
+      anon_sym_POUND,
+    ACTIONS(49), 1,
+      aux_sym_int_token2,
+    STATE(25), 1,
+      sym_reg,
+    STATE(49), 1,
+      sym_line_comment,
+    ACTIONS(55), 2,
+      sym_meta_ident,
+      sym__ident,
+    STATE(109), 2,
+      sym_int,
+      sym_ident,
+    ACTIONS(53), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+  [1804] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3353,7 +3405,7 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
     ACTIONS(161), 1,
       anon_sym_LF,
-    STATE(49), 2,
+    STATE(50), 2,
       sym_line_comment,
       aux_sym_program_repeat1,
     ACTIONS(164), 5,
@@ -3362,38 +3414,59 @@ static const uint16_t ts_small_parse_table[] = {
       sym_word,
       sym_meta_ident,
       sym__ident,
-  [1787] = 6,
+  [1831] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(50), 1,
+    ACTIONS(166), 1,
+      sym_address,
+    STATE(25), 1,
+      sym_reg,
+    STATE(51), 1,
       sym_line_comment,
-    ACTIONS(166), 2,
+    STATE(105), 1,
+      sym_ident,
+    ACTIONS(53), 2,
+      sym_word,
+      sym__reg,
+    ACTIONS(55), 2,
+      sym_meta_ident,
+      sym__ident,
+  [1861] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(52), 1,
+      sym_line_comment,
+    ACTIONS(168), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    ACTIONS(168), 5,
+    ACTIONS(170), 5,
       anon_sym_label,
       anon_sym_const,
       sym_word,
       sym_meta_ident,
       sym__ident,
-  [1811] = 9,
+  [1885] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(170), 1,
+    ACTIONS(166), 1,
       sym_address,
-    STATE(26), 1,
+    STATE(25), 1,
       sym_reg,
-    STATE(51), 1,
+    STATE(53), 1,
       sym_line_comment,
-    STATE(104), 1,
+    STATE(108), 1,
       sym_ident,
     ACTIONS(53), 2,
       sym_word,
@@ -3401,28 +3474,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(55), 2,
       sym_meta_ident,
       sym__ident,
-  [1841] = 9,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(170), 1,
-      sym_address,
-    STATE(26), 1,
-      sym_reg,
-    STATE(52), 1,
-      sym_line_comment,
-    STATE(98), 1,
-      sym_ident,
-    ACTIONS(53), 2,
-      sym_word,
-      sym__reg,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-  [1871] = 7,
+  [1915] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3430,80 +3482,67 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(174), 1,
-      anon_sym_COMMA,
-    STATE(53), 1,
+      anon_sym_LPAREN,
+    ACTIONS(176), 1,
+      sym_meta_ident,
+    STATE(54), 1,
       sym_line_comment,
-    STATE(56), 1,
-      aux_sym_meta_repeat3,
+    STATE(97), 1,
+      sym_meta,
     ACTIONS(172), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1894] = 8,
+  [1941] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(139), 1,
-      anon_sym_LF,
     ACTIONS(176), 1,
-      ts_builtin_sym_end,
-    STATE(22), 1,
-      aux_sym_program_repeat1,
-    STATE(54), 1,
-      sym_line_comment,
-    STATE(73), 1,
-      aux_sym_program_repeat2,
-  [1919] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
+      sym_meta_ident,
     ACTIONS(180), 1,
-      anon_sym_COMMA,
+      anon_sym_LPAREN,
     STATE(55), 1,
       sym_line_comment,
-    STATE(65), 1,
-      aux_sym_meta_repeat2,
+    STATE(99), 1,
+      sym_meta,
     ACTIONS(178), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1942] = 7,
+  [1967] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(174), 1,
+    ACTIONS(184), 1,
       anon_sym_COMMA,
     STATE(56), 1,
       sym_line_comment,
-    STATE(66), 1,
-      aux_sym_meta_repeat3,
-    ACTIONS(178), 2,
+    STATE(78), 1,
+      aux_sym_meta_repeat2,
+    ACTIONS(182), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1965] = 7,
+  [1990] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(182), 1,
-      anon_sym_COMMA,
+    ACTIONS(53), 1,
+      sym__reg,
     STATE(57), 1,
       sym_line_comment,
-    STATE(67), 1,
-      aux_sym_meta_repeat1,
-    ACTIONS(178), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1988] = 7,
+    STATE(80), 1,
+      sym_reg,
+    ACTIONS(166), 2,
+      sym_word,
+      sym_address,
+  [2013] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3514,43 +3553,26 @@ static const uint16_t ts_small_parse_table[] = {
       sym__reg,
     STATE(58), 1,
       sym_line_comment,
-    STATE(115), 1,
+    STATE(77), 1,
       sym_reg,
-    ACTIONS(170), 2,
+    ACTIONS(166), 2,
       sym_word,
       sym_address,
-  [2011] = 7,
+  [2036] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(184), 1,
+    ACTIONS(188), 1,
+      anon_sym_COMMA,
+    ACTIONS(186), 2,
       ts_builtin_sym_end,
-    ACTIONS(186), 1,
       anon_sym_LF,
-    STATE(36), 1,
-      aux_sym_program_repeat1,
     STATE(59), 2,
       sym_line_comment,
-      aux_sym_program_repeat2,
-  [2034] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(53), 1,
-      sym__reg,
-    STATE(60), 1,
-      sym_line_comment,
-    STATE(82), 1,
-      sym_reg,
-    ACTIONS(170), 2,
-      sym_word,
-      sym_address,
+      aux_sym_meta_repeat1,
   [2057] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
@@ -3558,11 +3580,11 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(191), 1,
+    ACTIONS(193), 1,
       anon_sym_BANG,
-    STATE(61), 1,
+    STATE(60), 1,
       sym_line_comment,
-    ACTIONS(189), 3,
+    ACTIONS(191), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
@@ -3573,30 +3595,47 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(64), 1,
-      anon_sym_LPAREN,
-    STATE(62), 1,
-      sym_line_comment,
-    ACTIONS(62), 3,
+    ACTIONS(197), 1,
+      anon_sym_COMMA,
+    ACTIONS(195), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-  [2099] = 6,
+    STATE(61), 2,
+      sym_line_comment,
+      aux_sym_meta_repeat3,
+  [2099] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(195), 1,
+    ACTIONS(200), 1,
       anon_sym_COMMA,
-    ACTIONS(193), 2,
+    STATE(61), 1,
+      aux_sym_meta_repeat3,
+    STATE(62), 1,
+      sym_line_comment,
+    ACTIONS(182), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    STATE(63), 2,
+  [2122] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(202), 1,
+      anon_sym_COMMA,
+    STATE(59), 1,
+      aux_sym_meta_repeat1,
+    STATE(63), 1,
       sym_line_comment,
-      aux_sym_instruction_repeat1,
-  [2120] = 7,
+    ACTIONS(182), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2145] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3607,12 +3646,106 @@ static const uint16_t ts_small_parse_table[] = {
       sym__reg,
     STATE(64), 1,
       sym_line_comment,
-    STATE(68), 1,
+    STATE(106), 1,
       sym_reg,
-    ACTIONS(170), 2,
+    ACTIONS(166), 2,
       sym_word,
       sym_address,
-  [2143] = 6,
+  [2168] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(53), 1,
+      sym__reg,
+    STATE(65), 1,
+      sym_line_comment,
+    STATE(101), 1,
+      sym_reg,
+    ACTIONS(166), 2,
+      sym_word,
+      sym_address,
+  [2191] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(204), 1,
+      ts_builtin_sym_end,
+    ACTIONS(206), 1,
+      anon_sym_LF,
+    STATE(38), 1,
+      aux_sym_program_repeat1,
+    STATE(66), 2,
+      sym_line_comment,
+      aux_sym_program_repeat2,
+  [2214] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(209), 1,
+      anon_sym_COMMA,
+    STATE(67), 1,
+      sym_line_comment,
+    STATE(75), 1,
+      aux_sym_instruction_repeat1,
+    ACTIONS(108), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2237] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(184), 1,
+      anon_sym_COMMA,
+    STATE(56), 1,
+      aux_sym_meta_repeat2,
+    STATE(68), 1,
+      sym_line_comment,
+    ACTIONS(211), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2260] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(215), 1,
+      anon_sym_BANG,
+    STATE(69), 1,
+      sym_line_comment,
+    ACTIONS(213), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2281] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(64), 1,
+      anon_sym_LPAREN,
+    STATE(70), 1,
+      sym_line_comment,
+    ACTIONS(62), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2302] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3621,122 +3754,78 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(200), 1,
       anon_sym_COMMA,
-    ACTIONS(198), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(65), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat2,
-  [2164] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(205), 1,
-      anon_sym_COMMA,
-    ACTIONS(203), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(66), 2,
-      sym_line_comment,
+    STATE(62), 1,
       aux_sym_meta_repeat3,
-  [2185] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(210), 1,
-      anon_sym_COMMA,
-    ACTIONS(208), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(67), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat1,
-  [2206] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(213), 1,
-      anon_sym_COMMA,
-    ACTIONS(217), 1,
-      anon_sym_RBRACK,
-    STATE(68), 1,
-      sym_line_comment,
-    ACTIONS(215), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [2229] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(221), 1,
-      anon_sym_BANG,
-    STATE(69), 1,
-      sym_line_comment,
-    ACTIONS(219), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2250] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(223), 1,
-      anon_sym_COMMA,
-    STATE(70), 1,
-      sym_line_comment,
-    STATE(72), 1,
-      aux_sym_instruction_repeat1,
-    ACTIONS(108), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2273] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(182), 1,
-      anon_sym_COMMA,
-    STATE(57), 1,
-      aux_sym_meta_repeat1,
     STATE(71), 1,
       sym_line_comment,
-    ACTIONS(172), 2,
+    ACTIONS(211), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2296] = 7,
+  [2325] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(225), 1,
+    ACTIONS(219), 1,
       anon_sym_COMMA,
-    STATE(63), 1,
-      aux_sym_instruction_repeat1,
-    STATE(72), 1,
-      sym_line_comment,
-    ACTIONS(45), 2,
+    ACTIONS(217), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2319] = 8,
+    STATE(72), 2,
+      sym_line_comment,
+      aux_sym_instruction_repeat1,
+  [2346] = 8,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(139), 1,
+      anon_sym_LF,
+    ACTIONS(222), 1,
+      ts_builtin_sym_end,
+    STATE(22), 1,
+      aux_sym_program_repeat1,
+    STATE(73), 1,
+      sym_line_comment,
+    STATE(76), 1,
+      aux_sym_program_repeat2,
+  [2371] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(202), 1,
+      anon_sym_COMMA,
+    STATE(63), 1,
+      aux_sym_meta_repeat1,
+    STATE(74), 1,
+      sym_line_comment,
+    ACTIONS(211), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2394] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(224), 1,
+      anon_sym_COMMA,
+    STATE(72), 1,
+      aux_sym_instruction_repeat1,
+    STATE(75), 1,
+      sym_line_comment,
+    ACTIONS(57), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2417] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3747,85 +3836,44 @@ static const uint16_t ts_small_parse_table[] = {
       ts_builtin_sym_end,
     ACTIONS(139), 1,
       anon_sym_LF,
-    STATE(23), 1,
+    STATE(27), 1,
       aux_sym_program_repeat1,
-    STATE(59), 1,
+    STATE(66), 1,
       aux_sym_program_repeat2,
-    STATE(73), 1,
-      sym_line_comment,
-  [2344] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(180), 1,
-      anon_sym_COMMA,
-    STATE(55), 1,
-      aux_sym_meta_repeat2,
-    STATE(74), 1,
-      sym_line_comment,
-    ACTIONS(172), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2367] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(53), 1,
-      sym__reg,
-    STATE(75), 1,
-      sym_line_comment,
-    STATE(111), 1,
-      sym_reg,
-    ACTIONS(170), 2,
-      sym_word,
-      sym_address,
-  [2390] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
     STATE(76), 1,
       sym_line_comment,
-    ACTIONS(203), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2408] = 6,
+  [2442] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(229), 1,
-      anon_sym_LPAREN,
+    ACTIONS(226), 1,
+      anon_sym_COMMA,
+    ACTIONS(230), 1,
+      anon_sym_RBRACK,
     STATE(77), 1,
       sym_line_comment,
-    ACTIONS(227), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2428] = 5,
+    ACTIONS(228), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [2465] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(78), 1,
-      sym_line_comment,
-    ACTIONS(62), 3,
+    ACTIONS(234), 1,
+      anon_sym_COMMA,
+    ACTIONS(232), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-  [2446] = 5,
+    STATE(78), 2,
+      sym_line_comment,
+      aux_sym_meta_repeat2,
+  [2486] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3834,24 +3882,25 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(79), 1,
       sym_line_comment,
-    ACTIONS(198), 3,
+    ACTIONS(195), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2464] = 5,
+  [2504] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(239), 1,
+      anon_sym_RBRACK,
     STATE(80), 1,
       sym_line_comment,
-    ACTIONS(189), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2482] = 5,
+    ACTIONS(237), 2,
+      anon_sym_PLUS,
+      anon_sym_DASH,
+  [2524] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3860,25 +3909,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(81), 1,
       sym_line_comment,
-    ACTIONS(208), 3,
+    ACTIONS(62), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2500] = 6,
+  [2542] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(233), 1,
-      anon_sym_RBRACK,
     STATE(82), 1,
       sym_line_comment,
-    ACTIONS(231), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [2520] = 5,
+    ACTIONS(241), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2560] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3887,11 +3935,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(83), 1,
       sym_line_comment,
-    ACTIONS(235), 3,
+    ACTIONS(217), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2538] = 5,
+  [2578] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3900,11 +3948,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(84), 1,
       sym_line_comment,
-    ACTIONS(219), 3,
+    ACTIONS(213), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2556] = 5,
+  [2596] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3913,11 +3961,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(85), 1,
       sym_line_comment,
-    ACTIONS(237), 3,
+    ACTIONS(243), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2574] = 5,
+  [2614] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3926,11 +3974,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(86), 1,
       sym_line_comment,
-    ACTIONS(239), 3,
+    ACTIONS(191), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2592] = 5,
+  [2632] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3939,38 +3987,37 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(87), 1,
       sym_line_comment,
-    ACTIONS(193), 3,
+    ACTIONS(232), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2610] = 6,
+  [2650] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(243), 1,
-      anon_sym_LPAREN,
     STATE(88), 1,
       sym_line_comment,
-    ACTIONS(241), 2,
+    ACTIONS(245), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2630] = 6,
+      anon_sym_COMMA,
+  [2668] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      aux_sym_int_token2,
-    STATE(81), 1,
-      sym_int,
     STATE(89), 1,
       sym_line_comment,
-  [2649] = 5,
+    ACTIONS(186), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2686] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3982,7 +4029,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(247), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2666] = 5,
+  [2703] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3991,10 +4038,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(91), 1,
       sym_line_comment,
-    ACTIONS(249), 2,
+    ACTIONS(204), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2683] = 5,
+  [2720] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4003,35 +4050,35 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(92), 1,
       sym_line_comment,
-    ACTIONS(251), 2,
+    ACTIONS(249), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2700] = 6,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(245), 1,
-      aux_sym_int_token2,
-    STATE(93), 1,
-      sym_line_comment,
-    STATE(99), 1,
-      sym_int,
-  [2719] = 5,
+  [2737] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(94), 1,
+    STATE(93), 1,
       sym_line_comment,
-    ACTIONS(184), 2,
+    ACTIONS(251), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2736] = 5,
+  [2754] = 6,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(47), 1,
+      anon_sym_POUND,
+    ACTIONS(253), 1,
+      aux_sym_int_token2,
+    STATE(94), 1,
+      sym_line_comment,
+    STATE(109), 1,
+      sym_int,
+  [2773] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4040,10 +4087,10 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(95), 1,
       sym_line_comment,
-    ACTIONS(253), 2,
+    ACTIONS(255), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2753] = 5,
+  [2790] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4052,67 +4099,60 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(96), 1,
       sym_line_comment,
-    ACTIONS(172), 2,
+    ACTIONS(211), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2770] = 6,
+  [2807] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(97), 1,
+      sym_line_comment,
+    ACTIONS(257), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2824] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(47), 1,
       anon_sym_POUND,
-    ACTIONS(245), 1,
+    ACTIONS(253), 1,
       aux_sym_int_token2,
-    STATE(97), 1,
-      sym_line_comment,
-    STATE(102), 1,
-      sym_int,
-  [2789] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(255), 1,
-      anon_sym_RPAREN,
     STATE(98), 1,
       sym_line_comment,
-  [2805] = 5,
+    STATE(110), 1,
+      sym_int,
+  [2843] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(233), 1,
-      anon_sym_RBRACK,
     STATE(99), 1,
       sym_line_comment,
-  [2821] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
+    ACTIONS(259), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2860] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(257), 1,
-      sym_word,
+    ACTIONS(47), 1,
+      anon_sym_POUND,
+    ACTIONS(253), 1,
+      aux_sym_int_token2,
+    STATE(89), 1,
+      sym_int,
     STATE(100), 1,
       sym_line_comment,
-  [2837] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(259), 1,
-      sym_word,
-    STATE(101), 1,
-      sym_line_comment,
-  [2853] = 5,
+  [2879] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4120,10 +4160,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(261), 1,
-      anon_sym_RBRACK,
-    STATE(102), 1,
+      anon_sym_RPAREN,
+    STATE(101), 1,
       sym_line_comment,
-  [2869] = 5,
+  [2895] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4131,10 +4171,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(263), 1,
-      anon_sym_LBRACK,
-    STATE(103), 1,
+      anon_sym_rel,
+    STATE(102), 1,
       sym_line_comment,
-  [2885] = 5,
+  [2911] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4142,10 +4182,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(265), 1,
-      anon_sym_RPAREN,
-    STATE(104), 1,
+      anon_sym_LBRACK,
+    STATE(103), 1,
       sym_line_comment,
-  [2901] = 5,
+  [2927] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4153,10 +4193,10 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(267), 1,
-      anon_sym_LBRACK,
-    STATE(105), 1,
+      anon_sym_RBRACK,
+    STATE(104), 1,
       sym_line_comment,
-  [2917] = 5,
+  [2943] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4164,43 +4204,65 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(269), 1,
-      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+    STATE(105), 1,
+      sym_line_comment,
+  [2959] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(215), 1,
+      anon_sym_RPAREN,
     STATE(106), 1,
       sym_line_comment,
-  [2933] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
+  [2975] = 5,
     ACTIONS(271), 1,
-      anon_sym_rel,
+      anon_sym_POUND,
+    ACTIONS(273), 1,
+      aux_sym_line_comment_token1,
+    ACTIONS(275), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(277), 1,
+      sym_block_comment,
     STATE(107), 1,
       sym_line_comment,
-  [2949] = 5,
+  [2991] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(273), 1,
-      aux_sym_int_token1,
+    ACTIONS(279), 1,
+      anon_sym_RPAREN,
     STATE(108), 1,
       sym_line_comment,
-  [2965] = 5,
-    ACTIONS(275), 1,
+  [3007] = 5,
+    ACTIONS(3), 1,
       anon_sym_POUND,
-    ACTIONS(277), 1,
-      aux_sym_line_comment_token1,
-    ACTIONS(279), 1,
+    ACTIONS(5), 1,
       aux_sym_line_comment_token2,
-    ACTIONS(281), 1,
+    ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(239), 1,
+      anon_sym_RBRACK,
     STATE(109), 1,
       sym_line_comment,
-  [2981] = 5,
+  [3023] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(281), 1,
+      anon_sym_RBRACK,
+    STATE(110), 1,
+      sym_line_comment,
+  [3039] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4208,21 +4270,76 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(283), 1,
-      sym_float,
-    STATE(110), 1,
+      aux_sym_int_token1,
+    STATE(111), 1,
       sym_line_comment,
-  [2997] = 5,
+  [3055] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(191), 1,
-      anon_sym_RPAREN,
-    STATE(111), 1,
+    ACTIONS(285), 1,
+      anon_sym_LBRACK,
+    STATE(112), 1,
       sym_line_comment,
-  [3013] = 5,
+  [3071] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(287), 1,
+      anon_sym_ptr,
+    STATE(113), 1,
+      sym_line_comment,
+  [3087] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(289), 1,
+      sym_float,
+    STATE(114), 1,
+      sym_line_comment,
+  [3103] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(291), 1,
+      aux_sym_int_token1,
+    STATE(115), 1,
+      sym_line_comment,
+  [3119] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(293), 1,
+      sym_string,
+    STATE(116), 1,
+      sym_line_comment,
+  [3135] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(295), 1,
+      ts_builtin_sym_end,
+    STATE(117), 1,
+      sym_line_comment,
+  [3151] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4231,68 +4348,35 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(23), 1,
       anon_sym_COLON,
-    STATE(112), 1,
+    STATE(118), 1,
       sym_line_comment,
-  [3029] = 5,
+  [3167] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(285), 1,
-      ts_builtin_sym_end,
-    STATE(113), 1,
-      sym_line_comment,
-  [3045] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(287), 1,
-      sym_string,
-    STATE(114), 1,
-      sym_line_comment,
-  [3061] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(289), 1,
-      anon_sym_RPAREN,
-    STATE(115), 1,
-      sym_line_comment,
-  [3077] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(291), 1,
-      anon_sym_ptr,
-    STATE(116), 1,
-      sym_line_comment,
-  [3093] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(293), 1,
-      aux_sym_int_token1,
-    STATE(117), 1,
-      sym_line_comment,
-  [3109] = 1,
-    ACTIONS(295), 1,
-      ts_builtin_sym_end,
-  [3113] = 1,
     ACTIONS(297), 1,
+      sym_word,
+    STATE(119), 1,
+      sym_line_comment,
+  [3183] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(299), 1,
+      sym_word,
+    STATE(120), 1,
+      sym_line_comment,
+  [3199] = 1,
+    ACTIONS(301), 1,
+      ts_builtin_sym_end,
+  [3203] = 1,
+    ACTIONS(303), 1,
       ts_builtin_sym_end,
 };
 
@@ -4304,152 +4388,155 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(7)] = 225,
   [SMALL_STATE(8)] = 259,
   [SMALL_STATE(9)] = 293,
-  [SMALL_STATE(10)] = 330,
+  [SMALL_STATE(10)] = 326,
   [SMALL_STATE(11)] = 363,
   [SMALL_STATE(12)] = 396,
-  [SMALL_STATE(13)] = 442,
-  [SMALL_STATE(14)] = 474,
+  [SMALL_STATE(13)] = 432,
+  [SMALL_STATE(14)] = 470,
   [SMALL_STATE(15)] = 512,
-  [SMALL_STATE(16)] = 554,
-  [SMALL_STATE(17)] = 586,
+  [SMALL_STATE(16)] = 544,
+  [SMALL_STATE(17)] = 590,
   [SMALL_STATE(18)] = 622,
   [SMALL_STATE(19)] = 656,
   [SMALL_STATE(20)] = 702,
   [SMALL_STATE(21)] = 746,
   [SMALL_STATE(22)] = 793,
   [SMALL_STATE(23)] = 839,
-  [SMALL_STATE(24)] = 885,
-  [SMALL_STATE(25)] = 915,
-  [SMALL_STATE(26)] = 945,
-  [SMALL_STATE(27)] = 975,
-  [SMALL_STATE(28)] = 1005,
-  [SMALL_STATE(29)] = 1044,
-  [SMALL_STATE(30)] = 1083,
-  [SMALL_STATE(31)] = 1122,
-  [SMALL_STATE(32)] = 1161,
-  [SMALL_STATE(33)] = 1200,
-  [SMALL_STATE(34)] = 1239,
-  [SMALL_STATE(35)] = 1278,
-  [SMALL_STATE(36)] = 1317,
-  [SMALL_STATE(37)] = 1360,
-  [SMALL_STATE(38)] = 1399,
-  [SMALL_STATE(39)] = 1438,
-  [SMALL_STATE(40)] = 1477,
-  [SMALL_STATE(41)] = 1504,
-  [SMALL_STATE(42)] = 1541,
-  [SMALL_STATE(43)] = 1576,
-  [SMALL_STATE(44)] = 1603,
-  [SMALL_STATE(45)] = 1636,
-  [SMALL_STATE(46)] = 1667,
-  [SMALL_STATE(47)] = 1696,
-  [SMALL_STATE(48)] = 1728,
-  [SMALL_STATE(49)] = 1760,
-  [SMALL_STATE(50)] = 1787,
-  [SMALL_STATE(51)] = 1811,
-  [SMALL_STATE(52)] = 1841,
-  [SMALL_STATE(53)] = 1871,
-  [SMALL_STATE(54)] = 1894,
-  [SMALL_STATE(55)] = 1919,
-  [SMALL_STATE(56)] = 1942,
-  [SMALL_STATE(57)] = 1965,
-  [SMALL_STATE(58)] = 1988,
-  [SMALL_STATE(59)] = 2011,
-  [SMALL_STATE(60)] = 2034,
-  [SMALL_STATE(61)] = 2057,
-  [SMALL_STATE(62)] = 2078,
-  [SMALL_STATE(63)] = 2099,
-  [SMALL_STATE(64)] = 2120,
-  [SMALL_STATE(65)] = 2143,
-  [SMALL_STATE(66)] = 2164,
-  [SMALL_STATE(67)] = 2185,
-  [SMALL_STATE(68)] = 2206,
-  [SMALL_STATE(69)] = 2229,
-  [SMALL_STATE(70)] = 2250,
-  [SMALL_STATE(71)] = 2273,
-  [SMALL_STATE(72)] = 2296,
-  [SMALL_STATE(73)] = 2319,
-  [SMALL_STATE(74)] = 2344,
-  [SMALL_STATE(75)] = 2367,
-  [SMALL_STATE(76)] = 2390,
-  [SMALL_STATE(77)] = 2408,
-  [SMALL_STATE(78)] = 2428,
-  [SMALL_STATE(79)] = 2446,
-  [SMALL_STATE(80)] = 2464,
-  [SMALL_STATE(81)] = 2482,
-  [SMALL_STATE(82)] = 2500,
-  [SMALL_STATE(83)] = 2520,
-  [SMALL_STATE(84)] = 2538,
-  [SMALL_STATE(85)] = 2556,
-  [SMALL_STATE(86)] = 2574,
-  [SMALL_STATE(87)] = 2592,
-  [SMALL_STATE(88)] = 2610,
-  [SMALL_STATE(89)] = 2630,
-  [SMALL_STATE(90)] = 2649,
-  [SMALL_STATE(91)] = 2666,
-  [SMALL_STATE(92)] = 2683,
-  [SMALL_STATE(93)] = 2700,
-  [SMALL_STATE(94)] = 2719,
-  [SMALL_STATE(95)] = 2736,
-  [SMALL_STATE(96)] = 2753,
-  [SMALL_STATE(97)] = 2770,
-  [SMALL_STATE(98)] = 2789,
-  [SMALL_STATE(99)] = 2805,
-  [SMALL_STATE(100)] = 2821,
-  [SMALL_STATE(101)] = 2837,
-  [SMALL_STATE(102)] = 2853,
-  [SMALL_STATE(103)] = 2869,
-  [SMALL_STATE(104)] = 2885,
-  [SMALL_STATE(105)] = 2901,
-  [SMALL_STATE(106)] = 2917,
-  [SMALL_STATE(107)] = 2933,
-  [SMALL_STATE(108)] = 2949,
-  [SMALL_STATE(109)] = 2965,
-  [SMALL_STATE(110)] = 2981,
-  [SMALL_STATE(111)] = 2997,
-  [SMALL_STATE(112)] = 3013,
-  [SMALL_STATE(113)] = 3029,
-  [SMALL_STATE(114)] = 3045,
-  [SMALL_STATE(115)] = 3061,
-  [SMALL_STATE(116)] = 3077,
-  [SMALL_STATE(117)] = 3093,
-  [SMALL_STATE(118)] = 3109,
-  [SMALL_STATE(119)] = 3113,
+  [SMALL_STATE(24)] = 869,
+  [SMALL_STATE(25)] = 899,
+  [SMALL_STATE(26)] = 929,
+  [SMALL_STATE(27)] = 973,
+  [SMALL_STATE(28)] = 1019,
+  [SMALL_STATE(29)] = 1049,
+  [SMALL_STATE(30)] = 1088,
+  [SMALL_STATE(31)] = 1127,
+  [SMALL_STATE(32)] = 1166,
+  [SMALL_STATE(33)] = 1205,
+  [SMALL_STATE(34)] = 1244,
+  [SMALL_STATE(35)] = 1283,
+  [SMALL_STATE(36)] = 1322,
+  [SMALL_STATE(37)] = 1361,
+  [SMALL_STATE(38)] = 1400,
+  [SMALL_STATE(39)] = 1443,
+  [SMALL_STATE(40)] = 1482,
+  [SMALL_STATE(41)] = 1521,
+  [SMALL_STATE(42)] = 1548,
+  [SMALL_STATE(43)] = 1577,
+  [SMALL_STATE(44)] = 1608,
+  [SMALL_STATE(45)] = 1635,
+  [SMALL_STATE(46)] = 1672,
+  [SMALL_STATE(47)] = 1705,
+  [SMALL_STATE(48)] = 1740,
+  [SMALL_STATE(49)] = 1772,
+  [SMALL_STATE(50)] = 1804,
+  [SMALL_STATE(51)] = 1831,
+  [SMALL_STATE(52)] = 1861,
+  [SMALL_STATE(53)] = 1885,
+  [SMALL_STATE(54)] = 1915,
+  [SMALL_STATE(55)] = 1941,
+  [SMALL_STATE(56)] = 1967,
+  [SMALL_STATE(57)] = 1990,
+  [SMALL_STATE(58)] = 2013,
+  [SMALL_STATE(59)] = 2036,
+  [SMALL_STATE(60)] = 2057,
+  [SMALL_STATE(61)] = 2078,
+  [SMALL_STATE(62)] = 2099,
+  [SMALL_STATE(63)] = 2122,
+  [SMALL_STATE(64)] = 2145,
+  [SMALL_STATE(65)] = 2168,
+  [SMALL_STATE(66)] = 2191,
+  [SMALL_STATE(67)] = 2214,
+  [SMALL_STATE(68)] = 2237,
+  [SMALL_STATE(69)] = 2260,
+  [SMALL_STATE(70)] = 2281,
+  [SMALL_STATE(71)] = 2302,
+  [SMALL_STATE(72)] = 2325,
+  [SMALL_STATE(73)] = 2346,
+  [SMALL_STATE(74)] = 2371,
+  [SMALL_STATE(75)] = 2394,
+  [SMALL_STATE(76)] = 2417,
+  [SMALL_STATE(77)] = 2442,
+  [SMALL_STATE(78)] = 2465,
+  [SMALL_STATE(79)] = 2486,
+  [SMALL_STATE(80)] = 2504,
+  [SMALL_STATE(81)] = 2524,
+  [SMALL_STATE(82)] = 2542,
+  [SMALL_STATE(83)] = 2560,
+  [SMALL_STATE(84)] = 2578,
+  [SMALL_STATE(85)] = 2596,
+  [SMALL_STATE(86)] = 2614,
+  [SMALL_STATE(87)] = 2632,
+  [SMALL_STATE(88)] = 2650,
+  [SMALL_STATE(89)] = 2668,
+  [SMALL_STATE(90)] = 2686,
+  [SMALL_STATE(91)] = 2703,
+  [SMALL_STATE(92)] = 2720,
+  [SMALL_STATE(93)] = 2737,
+  [SMALL_STATE(94)] = 2754,
+  [SMALL_STATE(95)] = 2773,
+  [SMALL_STATE(96)] = 2790,
+  [SMALL_STATE(97)] = 2807,
+  [SMALL_STATE(98)] = 2824,
+  [SMALL_STATE(99)] = 2843,
+  [SMALL_STATE(100)] = 2860,
+  [SMALL_STATE(101)] = 2879,
+  [SMALL_STATE(102)] = 2895,
+  [SMALL_STATE(103)] = 2911,
+  [SMALL_STATE(104)] = 2927,
+  [SMALL_STATE(105)] = 2943,
+  [SMALL_STATE(106)] = 2959,
+  [SMALL_STATE(107)] = 2975,
+  [SMALL_STATE(108)] = 2991,
+  [SMALL_STATE(109)] = 3007,
+  [SMALL_STATE(110)] = 3023,
+  [SMALL_STATE(111)] = 3039,
+  [SMALL_STATE(112)] = 3055,
+  [SMALL_STATE(113)] = 3071,
+  [SMALL_STATE(114)] = 3087,
+  [SMALL_STATE(115)] = 3103,
+  [SMALL_STATE(116)] = 3119,
+  [SMALL_STATE(117)] = 3135,
+  [SMALL_STATE(118)] = 3151,
+  [SMALL_STATE(119)] = 3167,
+  [SMALL_STATE(120)] = 3183,
+  [SMALL_STATE(121)] = 3199,
+  [SMALL_STATE(122)] = 3203,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0, 0, 0),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(100),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(101),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(120),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
   [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
   [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(112),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
   [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 1, 0, 1),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(116),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
   [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
   [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
-  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, 0, 1),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(117),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, 0, 1),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, 0, 1),
+  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, 0, 1),
   [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__expr, 1, 0, 0), REDUCE(sym__tc_expr, 1, 0, 0),
   [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1, 0, 0),
-  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
   [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tc_expr, 1, 0, 0),
   [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__tc_expr, 1, 0, 0),
   [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1, 0, 0),
@@ -4460,107 +4547,110 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ident, 1, 0, 0),
   [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1, 0, 0),
   [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_reg, 1, 0, 0),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
-  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [90] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [102] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
-  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tc_infix, 3, 0, 5),
-  [106] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tc_infix, 3, 0, 5),
+  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tc_infix, 3, 0, 5),
+  [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tc_infix, 3, 0, 5),
+  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
+  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [104] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [106] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
   [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, 0, 1),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
   [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0),
-  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(108),
+  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(111),
   [117] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(7),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(13),
+  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(15),
   [123] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(11),
-  [126] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(10),
+  [126] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(9),
   [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 1, 0, 1),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [133] = {.entry = {.count = 1, .reusable = false}}, SHIFT(74),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [133] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
+  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
   [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2, 0, 0),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
   [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3, 0, 0),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_const, 3, 0, 4),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [151] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_const, 3, 0, 4),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [155] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
   [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0),
-  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0), SHIFT_REPEAT(50),
+  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0), SHIFT_REPEAT(52),
   [164] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
-  [168] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, 0, 1),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1, 0, 0),
-  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, 0, 1),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
-  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0),
-  [186] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0), SHIFT_REPEAT(50),
-  [189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3, 0, 0),
-  [191] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [193] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0),
-  [195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
-  [198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0),
-  [200] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0), SHIFT_REPEAT(110),
-  [203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0),
-  [205] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0), SHIFT_REPEAT(114),
-  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0),
-  [210] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0), SHIFT_REPEAT(89),
-  [213] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [217] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
-  [219] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5, 0, 0),
-  [221] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [227] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 3),
-  [229] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [231] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [233] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [235] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4, 0, 0),
-  [237] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 6, 0, 0),
-  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7, 0, 0),
-  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 0),
-  [243] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [245] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1, 0, 0),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 3),
-  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 0),
-  [253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 2),
-  [255] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
-  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [271] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [275] = {.entry = {.count = 1, .reusable = false}}, SHIFT(109),
-  [277] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
-  [279] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
-  [281] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [285] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
-  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(80),
-  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [295] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2, 0, 0),
-  [297] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1, 0, 0),
+  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
+  [170] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
+  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 3),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 0),
+  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, 0, 1),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0),
+  [188] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0), SHIFT_REPEAT(100),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5, 0, 0),
+  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0),
+  [197] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0), SHIFT_REPEAT(116),
+  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
+  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0),
+  [206] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0), SHIFT_REPEAT(52),
+  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, 0, 1),
+  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3, 0, 0),
+  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0),
+  [219] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
+  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1, 0, 0),
+  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0),
+  [234] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0), SHIFT_REPEAT(114),
+  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7, 0, 0),
+  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 6, 0, 0),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4, 0, 0),
+  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 0),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1, 0, 0),
+  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 2),
+  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 3),
+  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 3, 0, 3),
+  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 3, 0, 0),
+  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [271] = {.entry = {.count = 1, .reusable = false}}, SHIFT(107),
+  [273] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
+  [275] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
+  [277] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [281] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
+  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [295] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1, 0, 0),
+  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2, 0, 0),
 };
 
 #ifdef __cplusplus

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t size);
-extern void *(*ts_current_calloc)(size_t count, size_t size);
-extern void *(*ts_current_realloc)(void *ptr, size_t size);
-extern void (*ts_current_free)(void *ptr);
+extern void *(*ts_current_malloc)(size_t);
+extern void *(*ts_current_calloc)(size_t, size_t);
+extern void *(*ts_current_realloc)(void *, size_t);
+extern void (*ts_current_free)(void *);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,7 +14,6 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
-#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -279,7 +278,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#pragma warning(default : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,7 +47,6 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
-  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {

--- a/test/corpus/labels_directives.test
+++ b/test/corpus/labels_directives.test
@@ -1,5 +1,5 @@
 ==========
-Basic label 
+Basic label
 ==========
 main:
 ---
@@ -7,7 +7,7 @@ main:
     (label (ident)))
 
 ==========
-Local label 
+Local label
 ==========
 .label:
 ---
@@ -78,4 +78,16 @@ Directive -- Multiple floating point args
         (meta_ident)
         (float)
         (float)))
+
+==========
+Label and Directive -- Single integer arg
+==========
+length: .word 8
+---
+(program
+      (label
+        (ident)
+        (meta
+          (meta_ident)
+          (int))))
 


### PR DESCRIPTION
Hello! There seems to be an error when there is a label followed by a directive (meta identifier) with only a single argument. The error does not happen with multiple arguments.

The following is an example of this issue with `length: .word 4`:

**Before:**
```
(program ; [0, 0] - [1, 0]
  (instruction ; [0, 0] - [0, 15]
    kind: (word) ; [0, 0] - [0, 6]
    (ERROR) ; [0, 6] - [0, 7]
    (ident ; [0, 8] - [0, 13]
      (meta_ident)) ; [0, 8] - [0, 13]
    (int))) ; [0, 14] - [0, 15]
```
Tree-sitter incorrectly identifies the `length` label as an instruction and thus has an `ERROR` node when parsing the `:` character.

**After:**
```
(program ; [0, 0] - [1, 0]
  (label ; [0, 0] - [0, 15]
    (ident) ; [0, 0] - [0, 6]
    (meta ; [0, 8] - [0, 15]
      kind: (meta_ident) ; [0, 8] - [0, 13]
      (int)))) ; [0, 14] - [0, 15]
```

Thanks!