### PR TITLE
feat: support for register lists (ARMv7)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -46,8 +46,16 @@ module.exports = grammar({
             ),
         const: $ => seq('const', field('name', $.word), field('value', $._tc_expr)),
         instruction: $ => seq(field('kind', $.word), choice(sep(',', $._expr), repeat($._tc_expr))),
+        _expr: $ => choice($.ptr, $.ident, $.int, $.string, $.float, $.list),
 
-        _expr: $ => choice($.ptr, $.ident, $.int, $.string, $.float),
+        // ARMv7
+        list: $ =>
+            seq(
+                '{',
+                optional(seq($.reg, repeat(seq(choice(',', '-'), $.reg)), optional(','))),
+                '}'
+            ),
+
         ptr: $ =>
             choice(
                 seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -387,6 +387,77 @@
         {
           "type": "SYMBOL",
           "name": "float"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "list"
+        }
+      ]
+    },
+    "list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "reg"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "-"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "reg"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -88,6 +88,10 @@
           "named": true
         },
         {
+          "type": "list",
+          "named": true
+        },
+        {
           "type": "ptr",
           "named": true
         },
@@ -145,6 +149,21 @@
     "type": "line_comment",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "reg",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "meta",
@@ -462,7 +481,15 @@
     "named": true
   },
   {
+    "type": "{",
+    "named": false
+  },
+  {
     "type": "|",
+    "named": false
+  },
+  {
+    "type": "}",
     "named": false
   }
 ]

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,11 +5,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 123
+#define STATE_COUNT 135
 #define LARGE_STATE_COUNT 3
-#define SYMBOL_COUNT 59
+#define SYMBOL_COUNT 63
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 38
+#define TOKEN_COUNT 40
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 6
 #define MAX_ALIAS_SEQUENCE_LENGTH 7
@@ -23,57 +23,61 @@ enum ts_symbol_identifiers {
   anon_sym_RPAREN = 5,
   anon_sym_label = 6,
   anon_sym_const = 7,
-  anon_sym_byte = 8,
-  anon_sym_word = 9,
-  anon_sym_dword = 10,
-  anon_sym_qword = 11,
-  anon_sym_ptr = 12,
-  anon_sym_LBRACK = 13,
-  anon_sym_PLUS = 14,
-  anon_sym_DASH = 15,
-  anon_sym_RBRACK = 16,
-  anon_sym_STAR = 17,
-  anon_sym_rel = 18,
-  anon_sym_BANG = 19,
-  anon_sym_SLASH = 20,
-  anon_sym_PERCENT = 21,
-  anon_sym_PIPE = 22,
-  anon_sym_CARET = 23,
-  anon_sym_AMP = 24,
-  anon_sym_POUND = 25,
-  aux_sym_int_token1 = 26,
-  aux_sym_int_token2 = 27,
-  sym_float = 28,
-  sym_string = 29,
-  sym_word = 30,
-  sym__reg = 31,
-  sym_address = 32,
-  sym_meta_ident = 33,
-  sym__ident = 34,
-  aux_sym_line_comment_token1 = 35,
-  aux_sym_line_comment_token2 = 36,
-  sym_block_comment = 37,
-  sym_program = 38,
-  sym__item = 39,
-  sym_meta = 40,
-  sym_label = 41,
-  sym_const = 42,
-  sym_instruction = 43,
-  sym__expr = 44,
-  sym_ptr = 45,
-  sym__tc_expr = 46,
-  sym_tc_infix = 47,
-  sym_int = 48,
-  sym_reg = 49,
-  sym_ident = 50,
-  sym_line_comment = 51,
-  aux_sym_program_repeat1 = 52,
-  aux_sym_program_repeat2 = 53,
-  aux_sym_meta_repeat1 = 54,
-  aux_sym_meta_repeat2 = 55,
-  aux_sym_meta_repeat3 = 56,
-  aux_sym_instruction_repeat1 = 57,
-  aux_sym_instruction_repeat2 = 58,
+  anon_sym_LBRACE = 8,
+  anon_sym_DASH = 9,
+  anon_sym_RBRACE = 10,
+  anon_sym_byte = 11,
+  anon_sym_word = 12,
+  anon_sym_dword = 13,
+  anon_sym_qword = 14,
+  anon_sym_ptr = 15,
+  anon_sym_LBRACK = 16,
+  anon_sym_PLUS = 17,
+  anon_sym_RBRACK = 18,
+  anon_sym_STAR = 19,
+  anon_sym_rel = 20,
+  anon_sym_BANG = 21,
+  anon_sym_SLASH = 22,
+  anon_sym_PERCENT = 23,
+  anon_sym_PIPE = 24,
+  anon_sym_CARET = 25,
+  anon_sym_AMP = 26,
+  anon_sym_POUND = 27,
+  aux_sym_int_token1 = 28,
+  aux_sym_int_token2 = 29,
+  sym_float = 30,
+  sym_string = 31,
+  sym_word = 32,
+  sym__reg = 33,
+  sym_address = 34,
+  sym_meta_ident = 35,
+  sym__ident = 36,
+  aux_sym_line_comment_token1 = 37,
+  aux_sym_line_comment_token2 = 38,
+  sym_block_comment = 39,
+  sym_program = 40,
+  sym__item = 41,
+  sym_meta = 42,
+  sym_label = 43,
+  sym_const = 44,
+  sym_instruction = 45,
+  sym__expr = 46,
+  sym_list = 47,
+  sym_ptr = 48,
+  sym__tc_expr = 49,
+  sym_tc_infix = 50,
+  sym_int = 51,
+  sym_reg = 52,
+  sym_ident = 53,
+  sym_line_comment = 54,
+  aux_sym_program_repeat1 = 55,
+  aux_sym_program_repeat2 = 56,
+  aux_sym_meta_repeat1 = 57,
+  aux_sym_meta_repeat2 = 58,
+  aux_sym_meta_repeat3 = 59,
+  aux_sym_instruction_repeat1 = 60,
+  aux_sym_instruction_repeat2 = 61,
+  aux_sym_list_repeat1 = 62,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -85,6 +89,9 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_RPAREN] = ")",
   [anon_sym_label] = "label",
   [anon_sym_const] = "const",
+  [anon_sym_LBRACE] = "{",
+  [anon_sym_DASH] = "-",
+  [anon_sym_RBRACE] = "}",
   [anon_sym_byte] = "byte",
   [anon_sym_word] = "word",
   [anon_sym_dword] = "dword",
@@ -92,7 +99,6 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_ptr] = "ptr",
   [anon_sym_LBRACK] = "[",
   [anon_sym_PLUS] = "+",
-  [anon_sym_DASH] = "-",
   [anon_sym_RBRACK] = "]",
   [anon_sym_STAR] = "*",
   [anon_sym_rel] = "rel",
@@ -122,6 +128,7 @@ static const char * const ts_symbol_names[] = {
   [sym_const] = "const",
   [sym_instruction] = "instruction",
   [sym__expr] = "_expr",
+  [sym_list] = "list",
   [sym_ptr] = "ptr",
   [sym__tc_expr] = "_tc_expr",
   [sym_tc_infix] = "tc_infix",
@@ -136,6 +143,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_meta_repeat3] = "meta_repeat3",
   [aux_sym_instruction_repeat1] = "instruction_repeat1",
   [aux_sym_instruction_repeat2] = "instruction_repeat2",
+  [aux_sym_list_repeat1] = "list_repeat1",
 };
 
 static const TSSymbol ts_symbol_map[] = {
@@ -147,6 +155,9 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_RPAREN] = anon_sym_RPAREN,
   [anon_sym_label] = anon_sym_label,
   [anon_sym_const] = anon_sym_const,
+  [anon_sym_LBRACE] = anon_sym_LBRACE,
+  [anon_sym_DASH] = anon_sym_DASH,
+  [anon_sym_RBRACE] = anon_sym_RBRACE,
   [anon_sym_byte] = anon_sym_byte,
   [anon_sym_word] = anon_sym_word,
   [anon_sym_dword] = anon_sym_dword,
@@ -154,7 +165,6 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_ptr] = anon_sym_ptr,
   [anon_sym_LBRACK] = anon_sym_LBRACK,
   [anon_sym_PLUS] = anon_sym_PLUS,
-  [anon_sym_DASH] = anon_sym_DASH,
   [anon_sym_RBRACK] = anon_sym_RBRACK,
   [anon_sym_STAR] = anon_sym_STAR,
   [anon_sym_rel] = anon_sym_rel,
@@ -184,6 +194,7 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_const] = sym_const,
   [sym_instruction] = sym_instruction,
   [sym__expr] = sym__expr,
+  [sym_list] = sym_list,
   [sym_ptr] = sym_ptr,
   [sym__tc_expr] = sym__tc_expr,
   [sym_tc_infix] = sym_tc_infix,
@@ -198,6 +209,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_meta_repeat3] = aux_sym_meta_repeat3,
   [aux_sym_instruction_repeat1] = aux_sym_instruction_repeat1,
   [aux_sym_instruction_repeat2] = aux_sym_instruction_repeat2,
+  [aux_sym_list_repeat1] = aux_sym_list_repeat1,
 };
 
 static const TSSymbolMetadata ts_symbol_metadata[] = {
@@ -233,6 +245,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_LBRACE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RBRACE] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_byte] = {
     .visible = true,
     .named = false,
@@ -258,10 +282,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_PLUS] = {
-    .visible = true,
-    .named = false,
-  },
-  [anon_sym_DASH] = {
     .visible = true,
     .named = false,
   },
@@ -381,6 +401,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = true,
   },
+  [sym_list] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_ptr] = {
     .visible = true,
     .named = true,
@@ -434,6 +458,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym_instruction_repeat2] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_list_repeat1] = {
     .visible = false,
     .named = false,
   },
@@ -513,32 +541,32 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [19] = 19,
   [20] = 20,
   [21] = 21,
-  [22] = 22,
-  [23] = 11,
-  [24] = 8,
-  [25] = 9,
+  [22] = 10,
+  [23] = 23,
+  [24] = 11,
+  [25] = 8,
   [26] = 26,
   [27] = 27,
   [28] = 7,
   [29] = 29,
   [30] = 30,
   [31] = 31,
-  [32] = 32,
-  [33] = 29,
+  [32] = 29,
+  [33] = 33,
   [34] = 34,
   [35] = 30,
-  [36] = 32,
-  [37] = 34,
-  [38] = 38,
-  [39] = 39,
-  [40] = 31,
-  [41] = 15,
-  [42] = 18,
-  [43] = 12,
-  [44] = 17,
-  [45] = 45,
-  [46] = 13,
-  [47] = 14,
+  [36] = 36,
+  [37] = 37,
+  [38] = 34,
+  [39] = 31,
+  [40] = 33,
+  [41] = 41,
+  [42] = 12,
+  [43] = 13,
+  [44] = 14,
+  [45] = 16,
+  [46] = 17,
+  [47] = 15,
   [48] = 48,
   [49] = 49,
   [50] = 50,
@@ -606,7 +634,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [112] = 112,
   [113] = 113,
   [114] = 114,
-  [115] = 111,
+  [115] = 115,
   [116] = 116,
   [117] = 117,
   [118] = 118,
@@ -614,6 +642,18 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [120] = 120,
   [121] = 121,
   [122] = 122,
+  [123] = 123,
+  [124] = 124,
+  [125] = 125,
+  [126] = 120,
+  [127] = 127,
+  [128] = 128,
+  [129] = 129,
+  [130] = 130,
+  [131] = 131,
+  [132] = 132,
+  [133] = 133,
+  [134] = 134,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -624,121 +664,123 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (eof) ADVANCE(29);
       ADVANCE_MAP(
         '\n', 30,
-        '!', 55,
+        '!', 57,
         '"', 1,
-        '#', 62,
+        '#', 64,
         '$', 18,
-        '%', 57,
-        '&', 61,
+        '%', 59,
+        '&', 63,
         '(', 33,
         ')', 34,
-        '*', 52,
-        '+', 48,
+        '*', 54,
+        '+', 52,
         ',', 31,
-        '-', 50,
-        '.', 143,
-        '/', 56,
-        '0', 71,
+        '-', 39,
+        '.', 145,
+        '/', 58,
+        '0', 73,
         ':', 32,
-        ';', 150,
-        '[', 47,
-        ']', 51,
-        '^', 60,
-        'b', 130,
-        'c', 106,
-        'd', 125,
-        'l', 91,
-        'p', 121,
-        'q', 126,
-        'r', 99,
-        'w', 108,
-        '|', 59,
+        ';', 152,
+        '[', 51,
+        ']', 53,
+        '^', 62,
+        'b', 132,
+        'c', 108,
+        'd', 127,
+        'l', 93,
+        'p', 123,
+        'q', 128,
+        'r', 101,
+        'w', 110,
+        '{', 37,
+        '|', 61,
+        '}', 40,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(74);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(76);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 1:
-      if (lookahead == '"') ADVANCE(90);
+      if (lookahead == '"') ADVANCE(92);
       if (lookahead != 0) ADVANCE(1);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '#', 62,
+        '#', 64,
         '$', 19,
         '-', 6,
         '/', 9,
-        '0', 81,
-        ';', 150,
+        '0', 83,
+        ';', 152,
         'p', 15,
         'r', 12,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(2);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(83);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(85);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(62);
+      if (lookahead == '#') ADVANCE(64);
       if (lookahead == '$') ADVANCE(23);
       if (lookahead == '%') ADVANCE(22);
-      if (lookahead == '.') ADVANCE(143);
+      if (lookahead == '.') ADVANCE(145);
       if (lookahead == '/') ADVANCE(9);
-      if (lookahead == ';') ADVANCE(150);
+      if (lookahead == ';') ADVANCE(152);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(3);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(62);
+      if (lookahead == '#') ADVANCE(64);
       if (lookahead == '$') ADVANCE(20);
       if (lookahead == '-') ADVANCE(8);
       if (lookahead == '/') ADVANCE(9);
-      if (lookahead == '0') ADVANCE(64);
-      if (lookahead == ';') ADVANCE(150);
+      if (lookahead == '0') ADVANCE(66);
+      if (lookahead == ';') ADVANCE(152);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(5);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(66);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(68);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(62);
+      if (lookahead == '#') ADVANCE(64);
       if (lookahead == '/') ADVANCE(9);
-      if (lookahead == ';') ADVANCE(150);
+      if (lookahead == ';') ADVANCE(152);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(5);
       END_STATE();
     case 6:
       if (lookahead == '$') ADVANCE(19);
-      if (lookahead == '0') ADVANCE(81);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(83);
+      if (lookahead == '0') ADVANCE(83);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(85);
       END_STATE();
     case 7:
       if (lookahead == '$') ADVANCE(19);
-      if (lookahead == '0') ADVANCE(79);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(80);
+      if (lookahead == '0') ADVANCE(81);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(82);
       END_STATE();
     case 8:
       if (lookahead == '$') ADVANCE(20);
-      if (lookahead == '0') ADVANCE(64);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(66);
+      if (lookahead == '0') ADVANCE(66);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(68);
       END_STATE();
     case 9:
       if (lookahead == '*') ADVANCE(11);
-      if (lookahead == '/') ADVANCE(150);
+      if (lookahead == '/') ADVANCE(152);
       END_STATE();
     case 10:
       if (lookahead == '*') ADVANCE(10);
-      if (lookahead == '/') ADVANCE(151);
+      if (lookahead == '/') ADVANCE(153);
       if (lookahead != 0) ADVANCE(11);
       END_STATE();
     case 11:
@@ -749,177 +791,180 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'e') ADVANCE(13);
       END_STATE();
     case 13:
-      if (lookahead == 'l') ADVANCE(53);
+      if (lookahead == 'l') ADVANCE(55);
       END_STATE();
     case 14:
-      if (lookahead == 'r') ADVANCE(45);
+      if (lookahead == 'r') ADVANCE(49);
       END_STATE();
     case 15:
       if (lookahead == 't') ADVANCE(14);
       END_STATE();
     case 16:
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(82);
+          lookahead == '1') ADVANCE(84);
       END_STATE();
     case 17:
       if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(65);
+          lookahead == '1') ADVANCE(67);
       END_STATE();
     case 18:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(84);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(86);
       if (('G' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(140);
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(142);
       END_STATE();
     case 19:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(85);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(87);
       END_STATE();
     case 20:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(67);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(69);
       END_STATE();
     case 21:
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
       END_STATE();
     case 22:
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
       END_STATE();
     case 23:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(140);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
       END_STATE();
     case 24:
       if (eof) ADVANCE(29);
       ADVANCE_MAP(
         '\n', 30,
         '"', 1,
-        '#', 62,
+        '#', 64,
         '$', 18,
         '%', 22,
         '(', 33,
-        '*', 52,
+        '*', 54,
         '-', 7,
-        '.', 143,
+        '.', 145,
         '/', 9,
-        '0', 76,
+        '0', 78,
         ':', 32,
-        ';', 150,
-        '[', 47,
-        'b', 129,
-        'd', 127,
-        'q', 128,
-        'w', 107,
+        ';', 152,
+        '[', 51,
+        'b', 131,
+        'd', 129,
+        'q', 130,
+        'w', 109,
+        '{', 37,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(24);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       END_STATE();
     case 25:
       if (eof) ADVANCE(29);
       ADVANCE_MAP(
         '\n', 30,
         '"', 1,
-        '#', 62,
+        '#', 64,
         '$', 18,
         '%', 22,
         '-', 7,
-        '.', 143,
+        '.', 145,
         '/', 9,
-        '0', 76,
+        '0', 78,
         ':', 32,
-        ';', 150,
+        ';', 152,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(25);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       END_STATE();
     case 26:
       if (eof) ADVANCE(29);
       ADVANCE_MAP(
         '\n', 30,
         '"', 1,
-        '#', 62,
+        '#', 64,
         '$', 18,
-        '%', 58,
-        '&', 61,
+        '%', 60,
+        '&', 63,
         '(', 33,
-        '*', 52,
-        '+', 48,
+        '*', 54,
+        '+', 52,
         ',', 31,
-        '-', 50,
-        '.', 143,
-        '/', 56,
-        '0', 68,
-        ';', 150,
-        '^', 60,
-        '|', 59,
+        '-', 39,
+        '.', 145,
+        '/', 58,
+        '0', 70,
+        ';', 152,
+        '^', 62,
+        '|', 61,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(26);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(69);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(71);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       END_STATE();
     case 27:
       if (eof) ADVANCE(29);
       ADVANCE_MAP(
         '\n', 30,
-        '#', 62,
+        '#', 64,
         '$', 23,
         '%', 22,
         '(', 33,
         '.', 21,
         '/', 9,
-        ';', 150,
+        ';', 152,
+        '}', 40,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(27);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(138);
+          lookahead == '_') ADVANCE(140);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
       END_STATE();
     case 28:
       if (eof) ADVANCE(29);
       ADVANCE_MAP(
         '\n', 30,
-        '#', 62,
-        '%', 57,
-        '&', 61,
+        '#', 64,
+        '%', 59,
+        '&', 63,
         '(', 33,
         ')', 34,
-        '*', 52,
-        '+', 48,
+        '*', 54,
+        '+', 52,
         ',', 31,
-        '-', 49,
-        '.', 143,
-        '/', 56,
-        ';', 150,
-        ']', 51,
-        '^', 60,
-        'c', 106,
-        'l', 91,
-        '|', 59,
+        '-', 38,
+        '.', 145,
+        '/', 58,
+        ';', 152,
+        ']', 53,
+        '^', 62,
+        'c', 108,
+        'l', 93,
+        '|', 61,
+        '}', 40,
       );
       if (lookahead == '\t' ||
           lookahead == '\r' ||
@@ -927,7 +972,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 29:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -949,781 +994,772 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 35:
       ACCEPT_TOKEN(anon_sym_label);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(anon_sym_const);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 37:
-      ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(anon_sym_byte);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 39:
-      ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 40:
-      ACCEPT_TOKEN(anon_sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 41:
-      ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 42:
-      ACCEPT_TOKEN(anon_sym_dword);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 43:
-      ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 44:
-      ACCEPT_TOKEN(anon_sym_qword);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 45:
-      ACCEPT_TOKEN(anon_sym_ptr);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(anon_sym_ptr);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 48:
-      ACCEPT_TOKEN(anon_sym_PLUS);
-      END_STATE();
-    case 49:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      END_STATE();
-    case 50:
       ACCEPT_TOKEN(anon_sym_DASH);
       if (lookahead == '$') ADVANCE(19);
-      if (lookahead == '0') ADVANCE(81);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(83);
+      if (lookahead == '0') ADVANCE(83);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(85);
       END_STATE();
-    case 51:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+    case 40:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 52:
-      ACCEPT_TOKEN(anon_sym_STAR);
+    case 41:
+      ACCEPT_TOKEN(anon_sym_byte);
+      if (lookahead == '.') ADVANCE(146);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
-    case 53:
-      ACCEPT_TOKEN(anon_sym_rel);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(anon_sym_rel);
-      if (lookahead == '.') ADVANCE(144);
+    case 42:
+      ACCEPT_TOKEN(anon_sym_byte);
+      if (lookahead == '.') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(anon_sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(anon_sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(anon_sym_dword);
+      if (lookahead == '.') ADVANCE(146);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 46:
+      ACCEPT_TOKEN(anon_sym_dword);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 47:
+      ACCEPT_TOKEN(anon_sym_qword);
+      if (lookahead == '.') ADVANCE(146);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 48:
+      ACCEPT_TOKEN(anon_sym_qword);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(anon_sym_ptr);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(anon_sym_ptr);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 51:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(anon_sym_PLUS);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_BANG);
+      ACCEPT_TOKEN(anon_sym_rel);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(11);
-      if (lookahead == '/') ADVANCE(150);
+      ACCEPT_TOKEN(anon_sym_rel);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 57:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_BANG);
       END_STATE();
     case 58:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(11);
+      if (lookahead == '/') ADVANCE(152);
       END_STATE();
     case 59:
-      ACCEPT_TOKEN(anon_sym_PIPE);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 60:
-      ACCEPT_TOKEN(anon_sym_CARET);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
       END_STATE();
     case 61:
-      ACCEPT_TOKEN(anon_sym_AMP);
+      ACCEPT_TOKEN(anon_sym_PIPE);
       END_STATE();
     case 62:
-      ACCEPT_TOKEN(anon_sym_POUND);
+      ACCEPT_TOKEN(anon_sym_CARET);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(anon_sym_POUND);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+      ACCEPT_TOKEN(anon_sym_AMP);
       END_STATE();
     case 64:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(151);
+      END_STATE();
+    case 66:
       ACCEPT_TOKEN(aux_sym_int_token1);
       if (lookahead == 'b') ADVANCE(17);
       if (lookahead == 'x') ADVANCE(20);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(66);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(aux_sym_int_token1);
-      if (lookahead == '0' ||
-          lookahead == '1' ||
-          lookahead == '_') ADVANCE(65);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(aux_sym_int_token1);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(66);
+          lookahead == '_') ADVANCE(68);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(aux_sym_int_token1);
+      if (lookahead == '0' ||
+          lookahead == '1' ||
+          lookahead == '_') ADVANCE(67);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(aux_sym_int_token1);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(68);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(aux_sym_int_token1);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(67);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == '_') ADVANCE(74);
-      if (lookahead == 'b') ADVANCE(132);
-      if (lookahead == 'x') ADVANCE(133);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == '_') ADVANCE(74);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(69);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(69);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == '_') ADVANCE(72);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(70);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
-      if (('2' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == '_') ADVANCE(76);
+      if (lookahead == 'b') ADVANCE(134);
+      if (lookahead == 'x') ADVANCE(135);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(71);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(138);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'b') ADVANCE(131);
-      if (lookahead == 'x') ADVANCE(134);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(74);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == '_') ADVANCE(76);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(71);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(138);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == '_') ADVANCE(74);
       if (lookahead == '0' ||
-          lookahead == '1' ||
-          lookahead == '_') ADVANCE(72);
+          lookahead == '1') ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(138);
       if (('2' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_') ADVANCE(75);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'b') ADVANCE(133);
+      if (lookahead == 'x') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(73);
-      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          lookahead == '_') ADVANCE(76);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == '0' ||
+          lookahead == '1' ||
           lookahead == '_') ADVANCE(74);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      if (('2' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
+      if (('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_') ADVANCE(77);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      if (('G' <= lookahead && lookahead <= 'Z')) ADVANCE(138);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(86);
-      if (lookahead == '_') ADVANCE(78);
-      if (lookahead == 'b') ADVANCE(132);
-      if (lookahead == 'x') ADVANCE(133);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(76);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(86);
-      if (lookahead == '_') ADVANCE(78);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(77);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(136);
-      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(77);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(86);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(78);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      if (lookahead == '.') ADVANCE(88);
+      if (lookahead == '_') ADVANCE(80);
+      if (lookahead == 'b') ADVANCE(134);
+      if (lookahead == 'x') ADVANCE(135);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(138);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(87);
-      if (lookahead == 'b') ADVANCE(16);
-      if (lookahead == 'x') ADVANCE(19);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(80);
+      if (lookahead == '.') ADVANCE(88);
+      if (lookahead == '_') ADVANCE(80);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(138);
+      if (('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '.') ADVANCE(87);
+      if (lookahead == '.') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(80);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(aux_sym_int_token2);
+      if (lookahead == '.') ADVANCE(89);
       if (lookahead == 'b') ADVANCE(16);
       if (lookahead == 'x') ADVANCE(19);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(83);
+          lookahead == '_') ADVANCE(82);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (lookahead == '0' ||
-          lookahead == '1' ||
+      if (lookahead == '.') ADVANCE(89);
+      if (('0' <= lookahead && lookahead <= '9') ||
           lookahead == '_') ADVANCE(82);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(aux_sym_int_token2);
+      if (lookahead == 'b') ADVANCE(16);
+      if (lookahead == 'x') ADVANCE(19);
       if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(83);
+          lookahead == '_') ADVANCE(85);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(aux_sym_int_token2);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(84);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(140);
+      if (lookahead == '0' ||
+          lookahead == '1' ||
+          lookahead == '_') ADVANCE(84);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(aux_sym_int_token2);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(85);
+          lookahead == '_') ADVANCE(85);
       END_STATE();
     case 86:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(88);
-      if (lookahead == '.' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+      ACCEPT_TOKEN(aux_sym_int_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(86);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(142);
       END_STATE();
     case 87:
-      ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(89);
+      ACCEPT_TOKEN(aux_sym_int_token2);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(87);
       END_STATE();
     case 88:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(88);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(90);
       if (lookahead == '.' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_float);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          lookahead == '_') ADVANCE(89);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(91);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(sym_string);
+      ACCEPT_TOKEN(sym_float);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(90);
+      if (lookahead == '.' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'a') ADVANCE(92);
+      ACCEPT_TOKEN(sym_float);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          lookahead == '_') ADVANCE(91);
       END_STATE();
     case 92:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'b') ADVANCE(102);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      ACCEPT_TOKEN(sym_string);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'd') ADVANCE(40);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'a') ADVANCE(94);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'd') ADVANCE(42);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'b') ADVANCE(104);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'd') ADVANCE(44);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'd') ADVANCE(39);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'd') ADVANCE(46);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'd') ADVANCE(41);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'd') ADVANCE(48);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'd') ADVANCE(43);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'e') ADVANCE(103);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'd') ADVANCE(45);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'e') ADVANCE(38);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'd') ADVANCE(47);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'e') ADVANCE(37);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(105);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'e') ADVANCE(104);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(42);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'l') ADVANCE(54);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(41);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'e') ADVANCE(106);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'l') ADVANCE(56);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'l') ADVANCE(35);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'n') ADVANCE(120);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'o') ADVANCE(105);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'o') ADVANCE(115);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'o') ADVANCE(114);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'n') ADVANCE(122);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'o') ADVANCE(107);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'o') ADVANCE(117);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'o') ADVANCE(116);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
-    case 110:
+    case 111:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'o') ADVANCE(118);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'o') ADVANCE(117);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'o') ADVANCE(119);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'o') ADVANCE(120);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'r') ADVANCE(46);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'o') ADVANCE(119);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'r') ADVANCE(93);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'o') ADVANCE(121);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'r') ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 116:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'r') ADVANCE(94);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(50);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
-    case 117:
+    case 116:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'r') ADVANCE(97);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 118:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'r') ADVANCE(95);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(96);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'r') ADVANCE(98);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(99);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 's') ADVANCE(122);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(97);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 't') ADVANCE(113);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'r') ADVANCE(100);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 's') ADVANCE(124);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(115);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 't') ADVANCE(36);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 't') ADVANCE(101);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 124:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 't') ADVANCE(100);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'w') ADVANCE(109);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(103);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'w') ADVANCE(110);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 't') ADVANCE(102);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'w') ADVANCE(111);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
       if (lookahead == 'w') ADVANCE(112);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'y') ADVANCE(123);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'w') ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == 'y') ADVANCE(124);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'w') ADVANCE(114);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(72);
-      if (('2' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'y') ADVANCE(125);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (lookahead == '0' ||
-          lookahead == '1') ADVANCE(70);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('2' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 133:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(73);
-      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      END_STATE();
-    case 134:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
-      if (('G' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(136);
-      END_STATE();
-    case 135:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(136);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
-      END_STATE();
-    case 136:
-      ACCEPT_TOKEN(sym_word);
-      if (lookahead == '.') ADVANCE(144);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == 'y') ADVANCE(126);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(136);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(74);
+      if (('2' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (lookahead == '0' ||
+          lookahead == '1') ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      if (('2' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (('A' <= lookahead && lookahead <= 'F')) ADVANCE(77);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(75);
+      if (('g' <= lookahead && lookahead <= 'z')) ADVANCE(137);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(138);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(77);
+      if (('G' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('g' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_') ADVANCE(138);
       if (('0' <= lookahead && lookahead <= '9') ||
@@ -1731,95 +1767,110 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym_word);
+      if (lookahead == '.') ADVANCE(146);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(138);
       END_STATE();
     case 139:
-      ACCEPT_TOKEN(sym__reg);
+      ACCEPT_TOKEN(sym_word);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(140);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(139);
       END_STATE();
     case 140:
-      ACCEPT_TOKEN(sym_address);
+      ACCEPT_TOKEN(sym_word);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(140);
       END_STATE();
     case 141:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
+      ACCEPT_TOKEN(sym__reg);
+      if (('0' <= lookahead && lookahead <= '9') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
-      if (lookahead == '.' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(144);
       END_STATE();
     case 142:
-      ACCEPT_TOKEN(sym_meta_ident);
-      if (lookahead == '_' ||
+      ACCEPT_TOKEN(sym_address);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(142);
       END_STATE();
     case 143:
-      ACCEPT_TOKEN(sym__ident);
+      ACCEPT_TOKEN(sym_meta_ident);
       if (lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(141);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(143);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(144);
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(146);
       END_STATE();
     case 144:
+      ACCEPT_TOKEN(sym_meta_ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(sym__ident);
+      if (lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(143);
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z')) ADVANCE(146);
+      END_STATE();
+    case 146:
       ACCEPT_TOKEN(sym__ident);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(144);
-      END_STATE();
-    case 145:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(11);
-      if (lookahead == '*') ADVANCE(145);
-      if (lookahead == '/') ADVANCE(149);
-      if (lookahead != 0) ADVANCE(146);
-      END_STATE();
-    case 146:
-      ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '\n') ADVANCE(11);
-      if (lookahead == '*') ADVANCE(145);
-      if (lookahead != 0) ADVANCE(146);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(146);
       END_STATE();
     case 147:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '#') ADVANCE(63);
-      if (lookahead == '/') ADVANCE(148);
-      if (lookahead == ';') ADVANCE(149);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(147);
-      if (lookahead != 0 &&
-          lookahead != '\t' &&
-          lookahead != '\n') ADVANCE(149);
+      if (lookahead == '\n') ADVANCE(11);
+      if (lookahead == '*') ADVANCE(147);
+      if (lookahead == '/') ADVANCE(151);
+      if (lookahead != 0) ADVANCE(148);
       END_STATE();
     case 148:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
-      if (lookahead == '*') ADVANCE(146);
-      if (lookahead == '/') ADVANCE(149);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+      if (lookahead == '\n') ADVANCE(11);
+      if (lookahead == '*') ADVANCE(147);
+      if (lookahead != 0) ADVANCE(148);
       END_STATE();
     case 149:
       ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '#') ADVANCE(65);
+      if (lookahead == '/') ADVANCE(150);
+      if (lookahead == ';') ADVANCE(151);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(149);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(149);
+          lookahead != '\t' &&
+          lookahead != '\n') ADVANCE(151);
       END_STATE();
     case 150:
-      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead == '*') ADVANCE(148);
+      if (lookahead == '/') ADVANCE(151);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(150);
+          lookahead != '\n') ADVANCE(151);
       END_STATE();
     case 151:
+      ACCEPT_TOKEN(aux_sym_line_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(151);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(aux_sym_line_comment_token2);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(152);
+      END_STATE();
+    case 153:
       ACCEPT_TOKEN(sym_block_comment);
       END_STATE();
     default:
@@ -1851,10 +1902,10 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [20] = {.lex_state = 26},
   [21] = {.lex_state = 25},
   [22] = {.lex_state = 28},
-  [23] = {.lex_state = 28},
+  [23] = {.lex_state = 25},
   [24] = {.lex_state = 28},
   [25] = {.lex_state = 28},
-  [26] = {.lex_state = 25},
+  [26] = {.lex_state = 28},
   [27] = {.lex_state = 28},
   [28] = {.lex_state = 28},
   [29] = {.lex_state = 26},
@@ -1864,9 +1915,9 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [33] = {.lex_state = 26},
   [34] = {.lex_state = 26},
   [35] = {.lex_state = 26},
-  [36] = {.lex_state = 26},
+  [36] = {.lex_state = 28},
   [37] = {.lex_state = 26},
-  [38] = {.lex_state = 28},
+  [38] = {.lex_state = 26},
   [39] = {.lex_state = 26},
   [40] = {.lex_state = 26},
   [41] = {.lex_state = 28},
@@ -1884,73 +1935,85 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [53] = {.lex_state = 3},
   [54] = {.lex_state = 27},
   [55] = {.lex_state = 27},
-  [56] = {.lex_state = 0},
+  [56] = {.lex_state = 27},
   [57] = {.lex_state = 27},
   [58] = {.lex_state = 27},
   [59] = {.lex_state = 0},
   [60] = {.lex_state = 0},
-  [61] = {.lex_state = 0},
+  [61] = {.lex_state = 27},
   [62] = {.lex_state = 0},
-  [63] = {.lex_state = 0},
-  [64] = {.lex_state = 27},
+  [63] = {.lex_state = 27},
+  [64] = {.lex_state = 0},
   [65] = {.lex_state = 27},
   [66] = {.lex_state = 0},
   [67] = {.lex_state = 0},
   [68] = {.lex_state = 0},
   [69] = {.lex_state = 0},
-  [70] = {.lex_state = 0},
+  [70] = {.lex_state = 28},
   [71] = {.lex_state = 0},
   [72] = {.lex_state = 0},
   [73] = {.lex_state = 0},
-  [74] = {.lex_state = 0},
-  [75] = {.lex_state = 0},
+  [74] = {.lex_state = 28},
+  [75] = {.lex_state = 27},
   [76] = {.lex_state = 0},
   [77] = {.lex_state = 28},
-  [78] = {.lex_state = 0},
+  [78] = {.lex_state = 27},
   [79] = {.lex_state = 0},
-  [80] = {.lex_state = 28},
+  [80] = {.lex_state = 0},
   [81] = {.lex_state = 0},
   [82] = {.lex_state = 0},
   [83] = {.lex_state = 0},
   [84] = {.lex_state = 0},
-  [85] = {.lex_state = 0},
+  [85] = {.lex_state = 28},
   [86] = {.lex_state = 0},
   [87] = {.lex_state = 0},
   [88] = {.lex_state = 0},
   [89] = {.lex_state = 0},
   [90] = {.lex_state = 0},
   [91] = {.lex_state = 0},
-  [92] = {.lex_state = 0},
+  [92] = {.lex_state = 28},
   [93] = {.lex_state = 0},
-  [94] = {.lex_state = 2},
+  [94] = {.lex_state = 0},
   [95] = {.lex_state = 0},
   [96] = {.lex_state = 0},
   [97] = {.lex_state = 0},
-  [98] = {.lex_state = 2},
+  [98] = {.lex_state = 0},
   [99] = {.lex_state = 0},
-  [100] = {.lex_state = 2},
-  [101] = {.lex_state = 0},
-  [102] = {.lex_state = 2},
+  [100] = {.lex_state = 0},
+  [101] = {.lex_state = 28},
+  [102] = {.lex_state = 0},
   [103] = {.lex_state = 0},
-  [104] = {.lex_state = 0},
+  [104] = {.lex_state = 2},
   [105] = {.lex_state = 0},
   [106] = {.lex_state = 0},
-  [107] = {.lex_state = 147},
+  [107] = {.lex_state = 2},
   [108] = {.lex_state = 0},
   [109] = {.lex_state = 0},
-  [110] = {.lex_state = 0},
-  [111] = {.lex_state = 4},
+  [110] = {.lex_state = 2},
+  [111] = {.lex_state = 0},
   [112] = {.lex_state = 0},
-  [113] = {.lex_state = 2},
+  [113] = {.lex_state = 149},
   [114] = {.lex_state = 24},
-  [115] = {.lex_state = 4},
+  [115] = {.lex_state = 0},
   [116] = {.lex_state = 0},
   [117] = {.lex_state = 0},
   [118] = {.lex_state = 0},
-  [119] = {.lex_state = 27},
-  [120] = {.lex_state = 27},
-  [121] = {(TSStateId)(-1)},
-  [122] = {(TSStateId)(-1)},
+  [119] = {.lex_state = 0},
+  [120] = {.lex_state = 4},
+  [121] = {.lex_state = 2},
+  [122] = {.lex_state = 0},
+  [123] = {.lex_state = 2},
+  [124] = {.lex_state = 0},
+  [125] = {.lex_state = 0},
+  [126] = {.lex_state = 4},
+  [127] = {.lex_state = 0},
+  [128] = {.lex_state = 0},
+  [129] = {.lex_state = 0},
+  [130] = {.lex_state = 0},
+  [131] = {.lex_state = 27},
+  [132] = {.lex_state = 27},
+  [133] = {(TSStateId)(-1)},
+  [134] = {(TSStateId)(-1)},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1964,6 +2027,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_RPAREN] = ACTIONS(1),
     [anon_sym_label] = ACTIONS(1),
     [anon_sym_const] = ACTIONS(1),
+    [anon_sym_LBRACE] = ACTIONS(1),
+    [anon_sym_DASH] = ACTIONS(1),
+    [anon_sym_RBRACE] = ACTIONS(1),
     [anon_sym_byte] = ACTIONS(1),
     [anon_sym_word] = ACTIONS(1),
     [anon_sym_dword] = ACTIONS(1),
@@ -1971,7 +2037,6 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_ptr] = ACTIONS(1),
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_PLUS] = ACTIONS(1),
-    [anon_sym_DASH] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_STAR] = ACTIONS(1),
     [anon_sym_rel] = ACTIONS(1),
@@ -1992,12 +2057,12 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [1] = {
-    [sym_program] = STATE(117),
-    [sym__item] = STATE(73),
-    [sym_meta] = STATE(92),
-    [sym_label] = STATE(92),
-    [sym_const] = STATE(92),
-    [sym_instruction] = STATE(92),
+    [sym_program] = STATE(129),
+    [sym__item] = STATE(62),
+    [sym_meta] = STATE(108),
+    [sym_label] = STATE(108),
+    [sym_const] = STATE(108),
+    [sym_instruction] = STATE(108),
     [sym_line_comment] = STATE(1),
     [ts_builtin_sym_end] = ACTIONS(9),
     [anon_sym_label] = ACTIONS(11),
@@ -2010,187 +2075,198 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_block_comment] = ACTIONS(7),
   },
   [2] = {
-    [sym__expr] = STATE(67),
-    [sym_ptr] = STATE(81),
-    [sym__tc_expr] = STATE(16),
-    [sym_tc_infix] = STATE(15),
+    [sym__expr] = STATE(68),
+    [sym_list] = STATE(95),
+    [sym_ptr] = STATE(95),
+    [sym__tc_expr] = STATE(18),
+    [sym_tc_infix] = STATE(17),
     [sym_int] = STATE(6),
-    [sym_reg] = STATE(9),
-    [sym_ident] = STATE(10),
+    [sym_reg] = STATE(11),
+    [sym_ident] = STATE(9),
     [sym_line_comment] = STATE(2),
-    [aux_sym_instruction_repeat2] = STATE(19),
+    [aux_sym_instruction_repeat2] = STATE(20),
     [ts_builtin_sym_end] = ACTIONS(21),
     [anon_sym_LF] = ACTIONS(21),
     [anon_sym_COLON] = ACTIONS(23),
     [anon_sym_LPAREN] = ACTIONS(25),
-    [anon_sym_byte] = ACTIONS(27),
-    [anon_sym_word] = ACTIONS(27),
-    [anon_sym_dword] = ACTIONS(27),
-    [anon_sym_qword] = ACTIONS(27),
-    [anon_sym_LBRACK] = ACTIONS(29),
-    [anon_sym_STAR] = ACTIONS(31),
-    [anon_sym_POUND] = ACTIONS(33),
-    [aux_sym_int_token2] = ACTIONS(35),
-    [sym_float] = ACTIONS(37),
-    [sym_string] = ACTIONS(39),
-    [sym_word] = ACTIONS(41),
-    [sym__reg] = ACTIONS(41),
-    [sym_address] = ACTIONS(41),
-    [sym_meta_ident] = ACTIONS(43),
-    [sym__ident] = ACTIONS(43),
+    [anon_sym_LBRACE] = ACTIONS(27),
+    [anon_sym_byte] = ACTIONS(29),
+    [anon_sym_word] = ACTIONS(29),
+    [anon_sym_dword] = ACTIONS(29),
+    [anon_sym_qword] = ACTIONS(29),
+    [anon_sym_LBRACK] = ACTIONS(31),
+    [anon_sym_STAR] = ACTIONS(33),
+    [anon_sym_POUND] = ACTIONS(35),
+    [aux_sym_int_token2] = ACTIONS(37),
+    [sym_float] = ACTIONS(39),
+    [sym_string] = ACTIONS(41),
+    [sym_word] = ACTIONS(43),
+    [sym__reg] = ACTIONS(43),
+    [sym_address] = ACTIONS(43),
+    [sym_meta_ident] = ACTIONS(45),
+    [sym__ident] = ACTIONS(45),
     [aux_sym_line_comment_token2] = ACTIONS(5),
     [sym_block_comment] = ACTIONS(7),
   },
 };
 
 static const uint16_t ts_small_parse_table[] = {
-  [0] = 18,
+  [0] = 19,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(25), 1,
       anon_sym_LPAREN,
-    ACTIONS(29), 1,
-      anon_sym_LBRACK,
+    ACTIONS(27), 1,
+      anon_sym_LBRACE,
     ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
       anon_sym_STAR,
-    ACTIONS(37), 1,
+    ACTIONS(39), 1,
       sym_float,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
-      aux_sym_int_token2,
+      anon_sym_POUND,
     ACTIONS(51), 1,
+      aux_sym_int_token2,
+    ACTIONS(53), 1,
       sym_string,
     STATE(3), 1,
       sym_line_comment,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
-    STATE(70), 1,
+    STATE(84), 1,
       sym_int,
-    STATE(83), 1,
+    STATE(90), 1,
       sym__expr,
-    ACTIONS(45), 2,
+    ACTIONS(47), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(81), 2,
-      sym_ptr,
-      sym_ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    ACTIONS(27), 4,
+    STATE(95), 3,
+      sym_list,
+      sym_ptr,
+      sym_ident,
+    ACTIONS(29), 4,
       anon_sym_byte,
       anon_sym_word,
       anon_sym_dword,
       anon_sym_qword,
-  [63] = 18,
+  [67] = 19,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(25), 1,
       anon_sym_LPAREN,
-    ACTIONS(29), 1,
-      anon_sym_LBRACK,
+    ACTIONS(27), 1,
+      anon_sym_LBRACE,
     ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
       anon_sym_STAR,
-    ACTIONS(37), 1,
+    ACTIONS(39), 1,
       sym_float,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
-      aux_sym_int_token2,
+      anon_sym_POUND,
     ACTIONS(51), 1,
+      aux_sym_int_token2,
+    ACTIONS(53), 1,
       sym_string,
     STATE(4), 1,
       sym_line_comment,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
-    STATE(70), 1,
+    STATE(84), 1,
       sym_int,
-    STATE(83), 1,
+    STATE(90), 1,
       sym__expr,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(57), 2,
+    ACTIONS(59), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    STATE(81), 2,
-      sym_ptr,
-      sym_ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    ACTIONS(27), 4,
+    STATE(95), 3,
+      sym_list,
+      sym_ptr,
+      sym_ident,
+    ACTIONS(29), 4,
       anon_sym_byte,
       anon_sym_word,
       anon_sym_dword,
       anon_sym_qword,
-  [126] = 17,
+  [134] = 18,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(25), 1,
       anon_sym_LPAREN,
-    ACTIONS(29), 1,
-      anon_sym_LBRACK,
+    ACTIONS(27), 1,
+      anon_sym_LBRACE,
     ACTIONS(31), 1,
+      anon_sym_LBRACK,
+    ACTIONS(33), 1,
       anon_sym_STAR,
-    ACTIONS(37), 1,
+    ACTIONS(39), 1,
       sym_float,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
-      aux_sym_int_token2,
+      anon_sym_POUND,
     ACTIONS(51), 1,
+      aux_sym_int_token2,
+    ACTIONS(53), 1,
       sym_string,
     STATE(5), 1,
       sym_line_comment,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
-    STATE(70), 1,
+    STATE(84), 1,
       sym_int,
-    STATE(83), 1,
+    STATE(90), 1,
       sym__expr,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(81), 2,
-      sym_ptr,
-      sym_ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    ACTIONS(27), 4,
+    STATE(95), 3,
+      sym_list,
+      sym_ptr,
+      sym_ident,
+    ACTIONS(29), 4,
       anon_sym_byte,
       anon_sym_word,
       anon_sym_dword,
       anon_sym_qword,
-  [185] = 8,
+  [197] = 8,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(62), 1,
-      anon_sym_COMMA,
     ACTIONS(64), 1,
+      anon_sym_COMMA,
+    ACTIONS(66), 1,
       anon_sym_LPAREN,
     STATE(6), 1,
       sym_line_comment,
-    ACTIONS(59), 2,
+    ACTIONS(61), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    ACTIONS(66), 7,
+    ACTIONS(70), 7,
       anon_sym_PLUS,
       anon_sym_STAR,
       anon_sym_PIPE,
@@ -2208,14 +2284,14 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [225] = 5,
+  [237] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     STATE(7), 1,
       sym_line_comment,
-    ACTIONS(72), 9,
+    ACTIONS(74), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2225,7 +2301,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(70), 11,
+    ACTIONS(72), 11,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
@@ -2237,14 +2313,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-  [259] = 5,
+  [271] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     STATE(8), 1,
       sym_line_comment,
-    ACTIONS(76), 9,
+    ACTIONS(78), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2254,7 +2330,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(74), 11,
+    ACTIONS(76), 11,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
@@ -2266,47 +2342,19 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-  [293] = 5,
+  [305] = 7,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(64), 1,
+      anon_sym_COMMA,
     STATE(9), 1,
       sym_line_comment,
-    ACTIONS(80), 9,
-      anon_sym_DASH,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-      aux_sym_int_token2,
-      sym_word,
-      sym__reg,
-      sym_address,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(78), 10,
+    ACTIONS(61), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-      anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-      anon_sym_POUND,
-      sym_string,
-  [326] = 7,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(62), 1,
-      anon_sym_COMMA,
-    STATE(10), 1,
-      sym_line_comment,
-    ACTIONS(59), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(66), 7,
+    ACTIONS(70), 7,
       anon_sym_PLUS,
       anon_sym_STAR,
       anon_sym_PIPE,
@@ -2324,14 +2372,42 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [363] = 5,
+  [342] = 5,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(10), 1,
+      sym_line_comment,
+    ACTIONS(82), 9,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+      aux_sym_int_token2,
+      sym_word,
+      sym__reg,
+      sym_address,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(80), 10,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+      anon_sym_POUND,
+      sym_string,
+  [375] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     STATE(11), 1,
       sym_line_comment,
-    ACTIONS(84), 9,
+    ACTIONS(86), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2341,7 +2417,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(82), 10,
+    ACTIONS(84), 10,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
@@ -2352,56 +2428,59 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-  [396] = 7,
+  [408] = 10,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(90), 1,
-      anon_sym_CARET,
     ACTIONS(92), 1,
+      anon_sym_STAR,
+    ACTIONS(96), 1,
+      anon_sym_PIPE,
+    ACTIONS(98), 1,
+      anon_sym_CARET,
+    ACTIONS(100), 1,
       anon_sym_AMP,
     STATE(12), 1,
       sym_line_comment,
-    ACTIONS(86), 7,
+    ACTIONS(94), 2,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
+    ACTIONS(88), 5,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_PIPE,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(88), 9,
+    ACTIONS(90), 7,
       anon_sym_DASH,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
       aux_sym_int_token2,
       sym_word,
       sym__reg,
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [432] = 8,
+  [450] = 8,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(90), 1,
-      anon_sym_CARET,
-    ACTIONS(92), 1,
-      anon_sym_AMP,
-    ACTIONS(94), 1,
+    ACTIONS(96), 1,
       anon_sym_PIPE,
+    ACTIONS(98), 1,
+      anon_sym_CARET,
+    ACTIONS(100), 1,
+      anon_sym_AMP,
     STATE(13), 1,
       sym_line_comment,
-    ACTIONS(86), 6,
+    ACTIONS(88), 6,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
       anon_sym_STAR,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(88), 9,
+    ACTIONS(90), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2411,56 +2490,54 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [470] = 10,
+  [488] = 7,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(90), 1,
+    ACTIONS(98), 1,
       anon_sym_CARET,
-    ACTIONS(92), 1,
+    ACTIONS(100), 1,
       anon_sym_AMP,
-    ACTIONS(94), 1,
-      anon_sym_PIPE,
-    ACTIONS(96), 1,
-      anon_sym_STAR,
     STATE(14), 1,
       sym_line_comment,
-    ACTIONS(98), 2,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(86), 5,
+    ACTIONS(88), 7,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PIPE,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(88), 7,
+    ACTIONS(90), 9,
       anon_sym_DASH,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
       aux_sym_int_token2,
       sym_word,
       sym__reg,
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [512] = 5,
+  [524] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(100), 1,
+      anon_sym_AMP,
     STATE(15), 1,
       sym_line_comment,
-    ACTIONS(66), 9,
+    ACTIONS(88), 8,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_PLUS,
       anon_sym_STAR,
       anon_sym_PIPE,
       anon_sym_CARET,
-      anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(68), 9,
+    ACTIONS(90), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2470,34 +2547,27 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [544] = 12,
+  [558] = 5,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(90), 1,
-      anon_sym_CARET,
-    ACTIONS(92), 1,
-      anon_sym_AMP,
-    ACTIONS(94), 1,
-      anon_sym_PIPE,
-    ACTIONS(96), 1,
-      anon_sym_STAR,
-    ACTIONS(102), 1,
-      anon_sym_PLUS,
-    ACTIONS(104), 1,
-      anon_sym_DASH,
     STATE(16), 1,
       sym_line_comment,
-    ACTIONS(98), 2,
-      anon_sym_SLASH,
-      anon_sym_PERCENT,
-    ACTIONS(100), 4,
+    ACTIONS(88), 9,
       ts_builtin_sym_end,
       anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
       anon_sym_POUND,
       sym_string,
-    ACTIONS(106), 6,
+    ACTIONS(90), 9,
+      anon_sym_DASH,
+      anon_sym_SLASH,
+      anon_sym_PERCENT,
       aux_sym_int_token2,
       sym_word,
       sym__reg,
@@ -2511,17 +2581,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(17), 1,
       sym_line_comment,
-    ACTIONS(86), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-      anon_sym_POUND,
-      sym_string,
-    ACTIONS(88), 9,
+    ACTIONS(68), 9,
       anon_sym_DASH,
       anon_sym_SLASH,
       anon_sym_PERCENT,
@@ -2531,268 +2591,253 @@ static const uint16_t ts_small_parse_table[] = {
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [622] = 6,
+    ACTIONS(70), 9,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+      anon_sym_POUND,
+      sym_string,
+  [622] = 12,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(92), 1,
+      anon_sym_STAR,
+    ACTIONS(96), 1,
+      anon_sym_PIPE,
+    ACTIONS(98), 1,
+      anon_sym_CARET,
+    ACTIONS(100), 1,
       anon_sym_AMP,
+    ACTIONS(104), 1,
+      anon_sym_DASH,
+    ACTIONS(106), 1,
+      anon_sym_PLUS,
     STATE(18), 1,
       sym_line_comment,
-    ACTIONS(86), 8,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_STAR,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_POUND,
-      sym_string,
-    ACTIONS(88), 9,
-      anon_sym_DASH,
+    ACTIONS(94), 2,
       anon_sym_SLASH,
       anon_sym_PERCENT,
+    ACTIONS(102), 4,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_POUND,
+      sym_string,
+    ACTIONS(108), 6,
       aux_sym_int_token2,
       sym_word,
       sym__reg,
       sym_address,
       sym_meta_ident,
       sym__ident,
-  [656] = 13,
+  [668] = 12,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(33), 1,
+    ACTIONS(112), 1,
       anon_sym_POUND,
-    ACTIONS(35), 1,
+    ACTIONS(115), 1,
       aux_sym_int_token2,
-    ACTIONS(110), 1,
+    ACTIONS(118), 1,
       sym_string,
-    STATE(9), 1,
+    STATE(11), 1,
       sym_reg,
-    STATE(16), 1,
+    STATE(18), 1,
+      sym__tc_expr,
+    ACTIONS(110), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    ACTIONS(124), 2,
+      sym_meta_ident,
+      sym__ident,
+    STATE(19), 2,
+      sym_line_comment,
+      aux_sym_instruction_repeat2,
+    ACTIONS(121), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    STATE(17), 3,
+      sym_tc_infix,
+      sym_int,
+      sym_ident,
+  [712] = 13,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(35), 1,
+      anon_sym_POUND,
+    ACTIONS(37), 1,
+      aux_sym_int_token2,
+    ACTIONS(129), 1,
+      sym_string,
+    STATE(11), 1,
+      sym_reg,
+    STATE(18), 1,
       sym__tc_expr,
     STATE(19), 1,
-      sym_line_comment,
+      aux_sym_instruction_repeat2,
     STATE(20), 1,
-      aux_sym_instruction_repeat2,
-    ACTIONS(43), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(108), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(41), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-    STATE(15), 3,
-      sym_tc_infix,
-      sym_int,
-      sym_ident,
-  [702] = 12,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(114), 1,
-      anon_sym_POUND,
-    ACTIONS(117), 1,
-      aux_sym_int_token2,
-    ACTIONS(120), 1,
-      sym_string,
-    STATE(9), 1,
-      sym_reg,
-    STATE(16), 1,
-      sym__tc_expr,
-    ACTIONS(112), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(126), 2,
-      sym_meta_ident,
-      sym__ident,
-    STATE(20), 2,
       sym_line_comment,
-      aux_sym_instruction_repeat2,
-    ACTIONS(123), 3,
+    ACTIONS(45), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(127), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    ACTIONS(43), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(15), 3,
+    STATE(17), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [746] = 14,
+  [758] = 14,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    ACTIONS(131), 1,
-      anon_sym_COLON,
     ACTIONS(133), 1,
-      sym_float,
+      anon_sym_COLON,
     ACTIONS(135), 1,
+      sym_float,
+    ACTIONS(137), 1,
       sym_string,
     STATE(21), 1,
       sym_line_comment,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
-    STATE(74), 1,
+    STATE(73), 1,
       sym_int,
-    STATE(96), 1,
+    STATE(109), 1,
       sym_ident,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(129), 2,
+    ACTIONS(131), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-  [793] = 14,
+  [805] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(11), 1,
-      anon_sym_label,
-    ACTIONS(13), 1,
-      anon_sym_const,
-    ACTIONS(15), 1,
-      sym_word,
-    ACTIONS(17), 1,
-      sym_meta_ident,
-    ACTIONS(19), 1,
-      sym__ident,
-    ACTIONS(137), 1,
-      ts_builtin_sym_end,
-    ACTIONS(139), 1,
-      anon_sym_LF,
+    ACTIONS(82), 1,
+      anon_sym_SLASH,
     STATE(22), 1,
       sym_line_comment,
-    STATE(50), 1,
-      aux_sym_program_repeat1,
-    STATE(91), 1,
-      sym__item,
-    STATE(92), 4,
-      sym_meta,
-      sym_label,
-      sym_const,
-      sym_instruction,
-  [839] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(84), 1,
-      anon_sym_SLASH,
-    STATE(23), 1,
-      sym_line_comment,
-    ACTIONS(82), 12,
+    ACTIONS(80), 13,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
       anon_sym_RPAREN,
-      anon_sym_PLUS,
       anon_sym_DASH,
+      anon_sym_RBRACE,
+      anon_sym_PLUS,
       anon_sym_RBRACK,
       anon_sym_STAR,
       anon_sym_PERCENT,
       anon_sym_PIPE,
       anon_sym_CARET,
       anon_sym_AMP,
-  [869] = 6,
+  [836] = 13,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
+      aux_sym_int_token2,
+    ACTIONS(135), 1,
+      sym_float,
+    ACTIONS(137), 1,
+      sym_string,
+    STATE(23), 1,
+      sym_line_comment,
+    STATE(24), 1,
+      sym_reg,
+    STATE(73), 1,
+      sym_int,
+    STATE(109), 1,
+      sym_ident,
+    ACTIONS(57), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(131), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    ACTIONS(55), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+  [880] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(76), 1,
+    ACTIONS(86), 1,
       anon_sym_SLASH,
     STATE(24), 1,
       sym_line_comment,
-    ACTIONS(74), 12,
+    ACTIONS(84), 12,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+      anon_sym_RPAREN,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+      anon_sym_RBRACK,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [910] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(78), 1,
+      anon_sym_SLASH,
+    STATE(25), 1,
+      sym_line_comment,
+    ACTIONS(76), 12,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
       anon_sym_LPAREN,
-      anon_sym_PLUS,
       anon_sym_DASH,
+      anon_sym_PLUS,
       anon_sym_RBRACK,
       anon_sym_STAR,
       anon_sym_PERCENT,
       anon_sym_PIPE,
       anon_sym_CARET,
       anon_sym_AMP,
-  [899] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(80), 1,
-      anon_sym_SLASH,
-    STATE(25), 1,
-      sym_line_comment,
-    ACTIONS(78), 12,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-      anon_sym_RPAREN,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_RBRACK,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [929] = 13,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(49), 1,
-      aux_sym_int_token2,
-    ACTIONS(133), 1,
-      sym_float,
-    ACTIONS(135), 1,
-      sym_string,
-    STATE(25), 1,
-      sym_reg,
-    STATE(26), 1,
-      sym_line_comment,
-    STATE(74), 1,
-      sym_int,
-    STATE(96), 1,
-      sym_ident,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(129), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(53), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-  [973] = 14,
+  [940] = 14,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -2810,297 +2855,273 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(19), 1,
       sym__ident,
     ACTIONS(139), 1,
-      anon_sym_LF,
+      ts_builtin_sym_end,
     ACTIONS(141), 1,
+      anon_sym_LF,
+    STATE(26), 1,
+      sym_line_comment,
+    STATE(50), 1,
+      aux_sym_program_repeat1,
+    STATE(112), 1,
+      sym__item,
+    STATE(108), 4,
+      sym_meta,
+      sym_label,
+      sym_const,
+      sym_instruction,
+  [986] = 14,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(11), 1,
+      anon_sym_label,
+    ACTIONS(13), 1,
+      anon_sym_const,
+    ACTIONS(15), 1,
+      sym_word,
+    ACTIONS(17), 1,
+      sym_meta_ident,
+    ACTIONS(19), 1,
+      sym__ident,
+    ACTIONS(141), 1,
+      anon_sym_LF,
+    ACTIONS(143), 1,
       ts_builtin_sym_end,
     STATE(27), 1,
       sym_line_comment,
     STATE(50), 1,
       aux_sym_program_repeat1,
-    STATE(91), 1,
+    STATE(112), 1,
       sym__item,
-    STATE(92), 4,
+    STATE(108), 4,
       sym_meta,
       sym_label,
       sym_const,
       sym_instruction,
-  [1019] = 6,
+  [1032] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(72), 1,
+    ACTIONS(74), 1,
       anon_sym_SLASH,
     STATE(28), 1,
       sym_line_comment,
-    ACTIONS(70), 12,
+    ACTIONS(72), 12,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
       anon_sym_LPAREN,
-      anon_sym_PLUS,
       anon_sym_DASH,
+      anon_sym_PLUS,
       anon_sym_RBRACK,
       anon_sym_STAR,
       anon_sym_PERCENT,
       anon_sym_PIPE,
       anon_sym_CARET,
       anon_sym_AMP,
-  [1049] = 11,
+  [1062] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    ACTIONS(143), 1,
+    ACTIONS(145), 1,
       sym_string,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
     STATE(29), 1,
       sym_line_comment,
-    STATE(46), 1,
+    STATE(44), 1,
       sym__tc_expr,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(41), 3,
+    STATE(46), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1088] = 11,
+  [1101] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(33), 1,
-      anon_sym_POUND,
     ACTIONS(35), 1,
+      anon_sym_POUND,
+    ACTIONS(37), 1,
       aux_sym_int_token2,
-    ACTIONS(110), 1,
+    ACTIONS(129), 1,
       sym_string,
-    STATE(9), 1,
+    STATE(11), 1,
       sym_reg,
-    STATE(17), 1,
+    STATE(16), 1,
       sym__tc_expr,
     STATE(30), 1,
       sym_line_comment,
-    ACTIONS(43), 2,
+    ACTIONS(45), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(41), 3,
+    ACTIONS(43), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(15), 3,
+    STATE(17), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1127] = 11,
+  [1140] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(33), 1,
-      anon_sym_POUND,
     ACTIONS(35), 1,
+      anon_sym_POUND,
+    ACTIONS(37), 1,
       aux_sym_int_token2,
-    ACTIONS(110), 1,
+    ACTIONS(129), 1,
       sym_string,
-    STATE(9), 1,
+    STATE(11), 1,
       sym_reg,
-    STATE(18), 1,
+    STATE(15), 1,
       sym__tc_expr,
     STATE(31), 1,
       sym_line_comment,
-    ACTIONS(43), 2,
+    ACTIONS(45), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(41), 3,
+    ACTIONS(43), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(15), 3,
+    STATE(17), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1166] = 11,
+  [1179] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(33), 1,
-      anon_sym_POUND,
     ACTIONS(35), 1,
+      anon_sym_POUND,
+    ACTIONS(37), 1,
       aux_sym_int_token2,
-    ACTIONS(110), 1,
+    ACTIONS(129), 1,
       sym_string,
-    STATE(9), 1,
+    STATE(11), 1,
       sym_reg,
-    STATE(12), 1,
+    STATE(14), 1,
       sym__tc_expr,
     STATE(32), 1,
       sym_line_comment,
-    ACTIONS(43), 2,
+    ACTIONS(45), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(41), 3,
+    ACTIONS(43), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(15), 3,
+    STATE(17), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1205] = 11,
+  [1218] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(33), 1,
-      anon_sym_POUND,
     ACTIONS(35), 1,
+      anon_sym_POUND,
+    ACTIONS(37), 1,
       aux_sym_int_token2,
-    ACTIONS(110), 1,
+    ACTIONS(129), 1,
       sym_string,
-    STATE(9), 1,
+    STATE(11), 1,
       sym_reg,
     STATE(13), 1,
       sym__tc_expr,
     STATE(33), 1,
       sym_line_comment,
-    ACTIONS(43), 2,
+    ACTIONS(45), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(41), 3,
+    ACTIONS(43), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(15), 3,
+    STATE(17), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1244] = 11,
+  [1257] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(33), 1,
-      anon_sym_POUND,
     ACTIONS(35), 1,
+      anon_sym_POUND,
+    ACTIONS(37), 1,
       aux_sym_int_token2,
-    ACTIONS(110), 1,
+    ACTIONS(129), 1,
       sym_string,
-    STATE(9), 1,
+    STATE(11), 1,
       sym_reg,
-    STATE(14), 1,
+    STATE(12), 1,
       sym__tc_expr,
     STATE(34), 1,
       sym_line_comment,
-    ACTIONS(43), 2,
+    ACTIONS(45), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(41), 3,
+    ACTIONS(43), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(15), 3,
+    STATE(17), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1283] = 11,
+  [1296] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    ACTIONS(143), 1,
+    ACTIONS(145), 1,
       sym_string,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
     STATE(35), 1,
       sym_line_comment,
-    STATE(44), 1,
+    STATE(45), 1,
       sym__tc_expr,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(41), 3,
+    STATE(46), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1322] = 11,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(49), 1,
-      aux_sym_int_token2,
-    ACTIONS(143), 1,
-      sym_string,
-    STATE(25), 1,
-      sym_reg,
-    STATE(36), 1,
-      sym_line_comment,
-    STATE(43), 1,
-      sym__tc_expr,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(53), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-    STATE(41), 3,
-      sym_tc_infix,
-      sym_int,
-      sym_ident,
-  [1361] = 11,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(49), 1,
-      aux_sym_int_token2,
-    ACTIONS(143), 1,
-      sym_string,
-    STATE(25), 1,
-      sym_reg,
-    STATE(37), 1,
-      sym_line_comment,
-    STATE(47), 1,
-      sym__tc_expr,
-    ACTIONS(55), 2,
-      sym_meta_ident,
-      sym__ident,
-    ACTIONS(53), 3,
-      sym_word,
-      sym__reg,
-      sym_address,
-    STATE(41), 3,
-      sym_tc_infix,
-      sym_int,
-      sym_ident,
-  [1400] = 13,
+  [1335] = 13,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3117,76 +3138,251 @@ static const uint16_t ts_small_parse_table[] = {
       sym_meta_ident,
     ACTIONS(19), 1,
       sym__ident,
-    ACTIONS(139), 1,
+    ACTIONS(141), 1,
       anon_sym_LF,
-    STATE(38), 1,
+    STATE(36), 1,
       sym_line_comment,
     STATE(50), 1,
       aux_sym_program_repeat1,
-    STATE(91), 1,
+    STATE(112), 1,
       sym__item,
-    STATE(92), 4,
+    STATE(108), 4,
       sym_meta,
       sym_label,
       sym_const,
       sym_instruction,
-  [1443] = 11,
+  [1378] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    ACTIONS(143), 1,
+    ACTIONS(145), 1,
       sym_string,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
-    STATE(39), 1,
+    STATE(37), 1,
       sym_line_comment,
-    STATE(45), 1,
+    STATE(41), 1,
       sym__tc_expr,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(41), 3,
+    STATE(46), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1482] = 11,
+  [1417] = 11,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    ACTIONS(143), 1,
+    ACTIONS(145), 1,
       sym_string,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
-    STATE(40), 1,
+    STATE(38), 1,
       sym_line_comment,
     STATE(42), 1,
       sym__tc_expr,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-    STATE(41), 3,
+    STATE(46), 3,
       sym_tc_infix,
       sym_int,
       sym_ident,
-  [1521] = 6,
+  [1456] = 11,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
+      aux_sym_int_token2,
+    ACTIONS(145), 1,
+      sym_string,
+    STATE(24), 1,
+      sym_reg,
+    STATE(39), 1,
+      sym_line_comment,
+    STATE(47), 1,
+      sym__tc_expr,
+    ACTIONS(57), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(55), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    STATE(46), 3,
+      sym_tc_infix,
+      sym_int,
+      sym_ident,
+  [1495] = 11,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
+      aux_sym_int_token2,
+    ACTIONS(145), 1,
+      sym_string,
+    STATE(24), 1,
+      sym_reg,
+    STATE(40), 1,
+      sym_line_comment,
+    STATE(43), 1,
+      sym__tc_expr,
+    ACTIONS(57), 2,
+      sym_meta_ident,
+      sym__ident,
+    ACTIONS(55), 3,
+      sym_word,
+      sym__reg,
+      sym_address,
+    STATE(46), 3,
+      sym_tc_infix,
+      sym_int,
+      sym_ident,
+  [1534] = 11,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(153), 1,
+      anon_sym_SLASH,
+    ACTIONS(155), 1,
+      anon_sym_PIPE,
+    ACTIONS(157), 1,
+      anon_sym_CARET,
+    ACTIONS(159), 1,
+      anon_sym_AMP,
+    STATE(41), 1,
+      sym_line_comment,
+    ACTIONS(147), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    ACTIONS(149), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+    ACTIONS(151), 2,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+  [1571] = 10,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(153), 1,
+      anon_sym_SLASH,
+    ACTIONS(155), 1,
+      anon_sym_PIPE,
+    ACTIONS(157), 1,
+      anon_sym_CARET,
+    ACTIONS(159), 1,
+      anon_sym_AMP,
+    STATE(42), 1,
+      sym_line_comment,
+    ACTIONS(151), 2,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+    ACTIONS(88), 4,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+  [1606] = 9,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(90), 1,
+      anon_sym_SLASH,
+    ACTIONS(155), 1,
+      anon_sym_PIPE,
+    ACTIONS(157), 1,
+      anon_sym_CARET,
+    ACTIONS(159), 1,
+      anon_sym_AMP,
+    STATE(43), 1,
+      sym_line_comment,
+    ACTIONS(88), 6,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+  [1639] = 8,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(90), 1,
+      anon_sym_SLASH,
+    ACTIONS(157), 1,
+      anon_sym_CARET,
+    ACTIONS(159), 1,
+      anon_sym_AMP,
+    STATE(44), 1,
+      sym_line_comment,
+    ACTIONS(88), 7,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+  [1670] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(90), 1,
+      anon_sym_SLASH,
+    STATE(45), 1,
+      sym_line_comment,
+    ACTIONS(88), 9,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [1697] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3195,247 +3391,128 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(68), 1,
       anon_sym_SLASH,
-    STATE(41), 1,
-      sym_line_comment,
-    ACTIONS(66), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [1548] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(88), 1,
-      anon_sym_SLASH,
-    ACTIONS(145), 1,
-      anon_sym_AMP,
-    STATE(42), 1,
-      sym_line_comment,
-    ACTIONS(86), 8,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-  [1577] = 8,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(88), 1,
-      anon_sym_SLASH,
-    ACTIONS(145), 1,
-      anon_sym_AMP,
-    ACTIONS(147), 1,
-      anon_sym_CARET,
-    STATE(43), 1,
-      sym_line_comment,
-    ACTIONS(86), 7,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-  [1608] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(88), 1,
-      anon_sym_SLASH,
-    STATE(44), 1,
-      sym_line_comment,
-    ACTIONS(86), 9,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-      anon_sym_PIPE,
-      anon_sym_CARET,
-      anon_sym_AMP,
-  [1635] = 11,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(145), 1,
-      anon_sym_AMP,
-    ACTIONS(147), 1,
-      anon_sym_CARET,
-    ACTIONS(155), 1,
-      anon_sym_SLASH,
-    ACTIONS(157), 1,
-      anon_sym_PIPE,
-    STATE(45), 1,
-      sym_line_comment,
-    ACTIONS(149), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    ACTIONS(151), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-    ACTIONS(153), 2,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-  [1672] = 9,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(88), 1,
-      anon_sym_SLASH,
-    ACTIONS(145), 1,
-      anon_sym_AMP,
-    ACTIONS(147), 1,
-      anon_sym_CARET,
-    ACTIONS(157), 1,
-      anon_sym_PIPE,
     STATE(46), 1,
       sym_line_comment,
-    ACTIONS(86), 6,
+    ACTIONS(70), 9,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_PLUS,
       anon_sym_DASH,
+      anon_sym_PLUS,
       anon_sym_STAR,
       anon_sym_PERCENT,
-  [1705] = 10,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+      anon_sym_AMP,
+  [1724] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(145), 1,
-      anon_sym_AMP,
-    ACTIONS(147), 1,
-      anon_sym_CARET,
-    ACTIONS(155), 1,
+    ACTIONS(90), 1,
       anon_sym_SLASH,
-    ACTIONS(157), 1,
-      anon_sym_PIPE,
+    ACTIONS(159), 1,
+      anon_sym_AMP,
     STATE(47), 1,
       sym_line_comment,
-    ACTIONS(153), 2,
-      anon_sym_STAR,
-      anon_sym_PERCENT,
-    ACTIONS(86), 4,
+    ACTIONS(88), 8,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_PLUS,
       anon_sym_DASH,
-  [1740] = 9,
+      anon_sym_PLUS,
+      anon_sym_STAR,
+      anon_sym_PERCENT,
+      anon_sym_PIPE,
+      anon_sym_CARET,
+  [1753] = 9,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
     STATE(48), 1,
       sym_line_comment,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(104), 2,
+    STATE(124), 2,
       sym_int,
       sym_ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-  [1772] = 9,
+  [1785] = 9,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
     ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(51), 1,
       aux_sym_int_token2,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
     STATE(49), 1,
       sym_line_comment,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-    STATE(109), 2,
+    STATE(116), 2,
       sym_int,
       sym_ident,
-    ACTIONS(53), 3,
+    ACTIONS(55), 3,
       sym_word,
       sym__reg,
       sym_address,
-  [1804] = 7,
+  [1817] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(159), 1,
-      ts_builtin_sym_end,
     ACTIONS(161), 1,
+      ts_builtin_sym_end,
+    ACTIONS(163), 1,
       anon_sym_LF,
     STATE(50), 2,
       sym_line_comment,
       aux_sym_program_repeat1,
-    ACTIONS(164), 5,
+    ACTIONS(166), 5,
       anon_sym_label,
       anon_sym_const,
       sym_word,
       sym_meta_ident,
       sym__ident,
-  [1831] = 9,
+  [1844] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(166), 1,
+    ACTIONS(168), 1,
       sym_address,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
     STATE(51), 1,
       sym_line_comment,
-    STATE(105), 1,
+    STATE(119), 1,
       sym_ident,
-    ACTIONS(53), 2,
+    ACTIONS(55), 2,
       sym_word,
       sym__reg,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-  [1861] = 6,
+  [1874] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3444,73 +3521,109 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(52), 1,
       sym_line_comment,
-    ACTIONS(168), 2,
+    ACTIONS(170), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    ACTIONS(170), 5,
+    ACTIONS(172), 5,
       anon_sym_label,
       anon_sym_const,
       sym_word,
       sym_meta_ident,
       sym__ident,
-  [1885] = 9,
+  [1898] = 9,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(166), 1,
+    ACTIONS(168), 1,
       sym_address,
-    STATE(25), 1,
+    STATE(24), 1,
       sym_reg,
     STATE(53), 1,
       sym_line_comment,
-    STATE(108), 1,
+    STATE(127), 1,
       sym_ident,
-    ACTIONS(53), 2,
+    ACTIONS(55), 2,
       sym_word,
       sym__reg,
-    ACTIONS(55), 2,
+    ACTIONS(57), 2,
       sym_meta_ident,
       sym__ident,
-  [1915] = 8,
+  [1928] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
     ACTIONS(174), 1,
-      anon_sym_LPAREN,
-    ACTIONS(176), 1,
-      sym_meta_ident,
+      anon_sym_RBRACE,
     STATE(54), 1,
       sym_line_comment,
-    STATE(97), 1,
-      sym_meta,
-    ACTIONS(172), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1941] = 8,
+    STATE(85), 1,
+      sym_reg,
+    ACTIONS(168), 2,
+      sym_word,
+      sym_address,
+  [1954] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
     ACTIONS(176), 1,
-      sym_meta_ident,
-    ACTIONS(180), 1,
-      anon_sym_LPAREN,
+      anon_sym_RBRACE,
     STATE(55), 1,
       sym_line_comment,
-    STATE(99), 1,
+    STATE(101), 1,
+      sym_reg,
+    ACTIONS(168), 2,
+      sym_word,
+      sym_address,
+  [1980] = 8,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
+    ACTIONS(178), 1,
+      anon_sym_RBRACE,
+    STATE(56), 1,
+      sym_line_comment,
+    STATE(101), 1,
+      sym_reg,
+    ACTIONS(168), 2,
+      sym_word,
+      sym_address,
+  [2006] = 8,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(182), 1,
+      anon_sym_LPAREN,
+    ACTIONS(184), 1,
+      sym_meta_ident,
+    STATE(57), 1,
+      sym_line_comment,
+    STATE(105), 1,
       sym_meta,
-    ACTIONS(178), 2,
+    ACTIONS(180), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [1967] = 7,
+  [2032] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3518,172 +3631,160 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(7), 1,
       sym_block_comment,
     ACTIONS(184), 1,
-      anon_sym_COMMA,
-    STATE(56), 1,
-      sym_line_comment,
-    STATE(78), 1,
-      aux_sym_meta_repeat2,
-    ACTIONS(182), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [1990] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(53), 1,
-      sym__reg,
-    STATE(57), 1,
-      sym_line_comment,
-    STATE(80), 1,
-      sym_reg,
-    ACTIONS(166), 2,
-      sym_word,
-      sym_address,
-  [2013] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(53), 1,
-      sym__reg,
+      sym_meta_ident,
+    ACTIONS(188), 1,
+      anon_sym_LPAREN,
     STATE(58), 1,
       sym_line_comment,
-    STATE(77), 1,
-      sym_reg,
-    ACTIONS(166), 2,
-      sym_word,
-      sym_address,
-  [2036] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(188), 1,
-      anon_sym_COMMA,
+    STATE(111), 1,
+      sym_meta,
     ACTIONS(186), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-    STATE(59), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat1,
-  [2057] = 6,
+  [2058] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(193), 1,
-      anon_sym_BANG,
-    STATE(60), 1,
-      sym_line_comment,
-    ACTIONS(191), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2078] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(197), 1,
-      anon_sym_COMMA,
-    ACTIONS(195), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(61), 2,
-      sym_line_comment,
-      aux_sym_meta_repeat3,
-  [2099] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(200), 1,
-      anon_sym_COMMA,
-    STATE(61), 1,
-      aux_sym_meta_repeat3,
-    STATE(62), 1,
-      sym_line_comment,
-    ACTIONS(182), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2122] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(202), 1,
+    ACTIONS(192), 1,
       anon_sym_COMMA,
     STATE(59), 1,
-      aux_sym_meta_repeat1,
-    STATE(63), 1,
       sym_line_comment,
-    ACTIONS(182), 2,
+    STATE(76), 1,
+      aux_sym_meta_repeat1,
+    ACTIONS(190), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2145] = 7,
+  [2081] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(53), 1,
-      sym__reg,
-    STATE(64), 1,
+    ACTIONS(196), 1,
+      anon_sym_COMMA,
+    ACTIONS(194), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    STATE(60), 2,
       sym_line_comment,
-    STATE(106), 1,
+      aux_sym_meta_repeat3,
+  [2102] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
+    STATE(61), 1,
+      sym_line_comment,
+    STATE(128), 1,
       sym_reg,
-    ACTIONS(166), 2,
+    ACTIONS(168), 2,
       sym_word,
       sym_address,
-  [2168] = 7,
+  [2125] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(53), 1,
+    ACTIONS(141), 1,
+      anon_sym_LF,
+    ACTIONS(199), 1,
+      ts_builtin_sym_end,
+    STATE(27), 1,
+      aux_sym_program_repeat1,
+    STATE(62), 1,
+      sym_line_comment,
+    STATE(82), 1,
+      aux_sym_program_repeat2,
+  [2150] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
+    STATE(63), 1,
+      sym_line_comment,
+    STATE(115), 1,
+      sym_reg,
+    ACTIONS(168), 2,
+      sym_word,
+      sym_address,
+  [2173] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(201), 1,
+      anon_sym_COMMA,
+    STATE(64), 1,
+      sym_line_comment,
+    STATE(80), 1,
+      aux_sym_meta_repeat2,
+    ACTIONS(190), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2196] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(55), 1,
       sym__reg,
     STATE(65), 1,
       sym_line_comment,
-    STATE(101), 1,
+    STATE(74), 1,
       sym_reg,
-    ACTIONS(166), 2,
+    ACTIONS(168), 2,
       sym_word,
       sym_address,
-  [2191] = 7,
+  [2219] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(204), 1,
-      ts_builtin_sym_end,
-    ACTIONS(206), 1,
-      anon_sym_LF,
-    STATE(38), 1,
-      aux_sym_program_repeat1,
-    STATE(66), 2,
+    ACTIONS(203), 1,
+      anon_sym_COMMA,
+    STATE(60), 1,
+      aux_sym_meta_repeat3,
+    STATE(66), 1,
       sym_line_comment,
-      aux_sym_program_repeat2,
-  [2214] = 7,
+    ACTIONS(190), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2242] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(207), 1,
+      anon_sym_BANG,
+    STATE(67), 1,
+      sym_line_comment,
+    ACTIONS(205), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2263] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3692,280 +3793,283 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(209), 1,
       anon_sym_COMMA,
-    STATE(67), 1,
-      sym_line_comment,
-    STATE(75), 1,
-      aux_sym_instruction_repeat1,
-    ACTIONS(108), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2237] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(184), 1,
-      anon_sym_COMMA,
-    STATE(56), 1,
-      aux_sym_meta_repeat2,
     STATE(68), 1,
       sym_line_comment,
-    ACTIONS(211), 2,
+    STATE(79), 1,
+      aux_sym_instruction_repeat1,
+    ACTIONS(127), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2260] = 6,
+  [2286] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(215), 1,
-      anon_sym_BANG,
+    ACTIONS(201), 1,
+      anon_sym_COMMA,
+    STATE(64), 1,
+      aux_sym_meta_repeat2,
     STATE(69), 1,
       sym_line_comment,
-    ACTIONS(213), 3,
+    ACTIONS(211), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-      anon_sym_COMMA,
-  [2281] = 6,
+  [2309] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(64), 1,
-      anon_sym_LPAREN,
-    STATE(70), 1,
+    ACTIONS(216), 1,
+      anon_sym_RBRACE,
+    ACTIONS(213), 2,
+      anon_sym_COMMA,
+      anon_sym_DASH,
+    STATE(70), 2,
       sym_line_comment,
-    ACTIONS(62), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2302] = 7,
+      aux_sym_list_repeat1,
+  [2330] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(200), 1,
+    ACTIONS(218), 1,
+      ts_builtin_sym_end,
+    ACTIONS(220), 1,
+      anon_sym_LF,
+    STATE(36), 1,
+      aux_sym_program_repeat1,
+    STATE(71), 2,
+      sym_line_comment,
+      aux_sym_program_repeat2,
+  [2353] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(203), 1,
       anon_sym_COMMA,
-    STATE(62), 1,
+    STATE(66), 1,
       aux_sym_meta_repeat3,
-    STATE(71), 1,
+    STATE(72), 1,
       sym_line_comment,
     ACTIONS(211), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2325] = 6,
+  [2376] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(219), 1,
+    ACTIONS(192), 1,
       anon_sym_COMMA,
-    ACTIONS(217), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(72), 2,
-      sym_line_comment,
-      aux_sym_instruction_repeat1,
-  [2346] = 8,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(139), 1,
-      anon_sym_LF,
-    ACTIONS(222), 1,
-      ts_builtin_sym_end,
-    STATE(22), 1,
-      aux_sym_program_repeat1,
+    STATE(59), 1,
+      aux_sym_meta_repeat1,
     STATE(73), 1,
       sym_line_comment,
-    STATE(76), 1,
-      aux_sym_program_repeat2,
-  [2371] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(202), 1,
-      anon_sym_COMMA,
-    STATE(63), 1,
-      aux_sym_meta_repeat1,
-    STATE(74), 1,
-      sym_line_comment,
     ACTIONS(211), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2394] = 7,
+  [2399] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(224), 1,
+    ACTIONS(223), 1,
       anon_sym_COMMA,
-    STATE(72), 1,
-      aux_sym_instruction_repeat1,
+    ACTIONS(227), 1,
+      anon_sym_RBRACK,
+    STATE(74), 1,
+      sym_line_comment,
+    ACTIONS(225), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+  [2422] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
     STATE(75), 1,
       sym_line_comment,
-    ACTIONS(57), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2417] = 8,
+    STATE(101), 1,
+      sym_reg,
+    ACTIONS(168), 2,
+      sym_word,
+      sym_address,
+  [2445] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(137), 1,
-      ts_builtin_sym_end,
-    ACTIONS(139), 1,
-      anon_sym_LF,
-    STATE(27), 1,
-      aux_sym_program_repeat1,
-    STATE(66), 1,
-      aux_sym_program_repeat2,
-    STATE(76), 1,
-      sym_line_comment,
-  [2442] = 7,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(226), 1,
+    ACTIONS(231), 1,
       anon_sym_COMMA,
-    ACTIONS(230), 1,
-      anon_sym_RBRACK,
-    STATE(77), 1,
+    ACTIONS(229), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    STATE(76), 2,
       sym_line_comment,
-    ACTIONS(228), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [2465] = 6,
+      aux_sym_meta_repeat1,
+  [2466] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(176), 1,
+      anon_sym_RBRACE,
     ACTIONS(234), 1,
       anon_sym_COMMA,
-    ACTIONS(232), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-    STATE(78), 2,
+    ACTIONS(236), 1,
+      anon_sym_DASH,
+    STATE(70), 1,
+      aux_sym_list_repeat1,
+    STATE(77), 1,
       sym_line_comment,
-      aux_sym_meta_repeat2,
-  [2486] = 5,
+  [2491] = 7,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(55), 1,
+      sym__reg,
+    STATE(78), 1,
+      sym_line_comment,
+    STATE(92), 1,
+      sym_reg,
+    ACTIONS(168), 2,
+      sym_word,
+      sym_address,
+  [2514] = 7,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(238), 1,
+      anon_sym_COMMA,
     STATE(79), 1,
       sym_line_comment,
-    ACTIONS(195), 3,
+    STATE(83), 1,
+      aux_sym_instruction_repeat1,
+    ACTIONS(47), 2,
       ts_builtin_sym_end,
       anon_sym_LF,
+  [2537] = 6,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(242), 1,
       anon_sym_COMMA,
-  [2504] = 6,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(239), 1,
-      anon_sym_RBRACK,
-    STATE(80), 1,
+    ACTIONS(240), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    STATE(80), 2,
       sym_line_comment,
-    ACTIONS(237), 2,
-      anon_sym_PLUS,
-      anon_sym_DASH,
-  [2524] = 5,
+      aux_sym_meta_repeat2,
+  [2558] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(247), 1,
+      anon_sym_BANG,
     STATE(81), 1,
       sym_line_comment,
-    ACTIONS(62), 3,
+    ACTIONS(245), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2542] = 5,
+  [2579] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(141), 1,
+      anon_sym_LF,
+    ACTIONS(143), 1,
+      ts_builtin_sym_end,
+    STATE(26), 1,
+      aux_sym_program_repeat1,
+    STATE(71), 1,
+      aux_sym_program_repeat2,
     STATE(82), 1,
       sym_line_comment,
-    ACTIONS(241), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2560] = 5,
+  [2604] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    STATE(83), 1,
+    ACTIONS(251), 1,
+      anon_sym_COMMA,
+    ACTIONS(249), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+    STATE(83), 2,
       sym_line_comment,
-    ACTIONS(217), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2578] = 5,
+      aux_sym_instruction_repeat1,
+  [2625] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(66), 1,
+      anon_sym_LPAREN,
     STATE(84), 1,
       sym_line_comment,
-    ACTIONS(213), 3,
+    ACTIONS(64), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2596] = 5,
+  [2646] = 8,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(236), 1,
+      anon_sym_DASH,
+    ACTIONS(254), 1,
+      anon_sym_COMMA,
+    ACTIONS(256), 1,
+      anon_sym_RBRACE,
+    STATE(77), 1,
+      aux_sym_list_repeat1,
     STATE(85), 1,
       sym_line_comment,
-    ACTIONS(243), 3,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-      anon_sym_COMMA,
-  [2614] = 5,
+  [2671] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3974,11 +4078,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(86), 1,
       sym_line_comment,
-    ACTIONS(191), 3,
+    ACTIONS(258), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2632] = 5,
+  [2689] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -3987,11 +4091,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(87), 1,
       sym_line_comment,
-    ACTIONS(232), 3,
+    ACTIONS(205), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2650] = 5,
+  [2707] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4000,11 +4104,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(88), 1,
       sym_line_comment,
-    ACTIONS(245), 3,
+    ACTIONS(260), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2668] = 5,
+  [2725] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4013,11 +4117,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(89), 1,
       sym_line_comment,
-    ACTIONS(186), 3,
+    ACTIONS(262), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
       anon_sym_COMMA,
-  [2686] = 5,
+  [2743] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4026,10 +4130,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(90), 1,
       sym_line_comment,
-    ACTIONS(247), 2,
+    ACTIONS(249), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2703] = 5,
+      anon_sym_COMMA,
+  [2761] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4038,22 +4143,25 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(91), 1,
       sym_line_comment,
-    ACTIONS(204), 2,
+    ACTIONS(264), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2720] = 5,
+      anon_sym_COMMA,
+  [2779] = 6,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(268), 1,
+      anon_sym_RBRACK,
     STATE(92), 1,
       sym_line_comment,
-    ACTIONS(249), 2,
-      ts_builtin_sym_end,
-      anon_sym_LF,
-  [2737] = 5,
+    ACTIONS(266), 2,
+      anon_sym_DASH,
+      anon_sym_PLUS,
+  [2799] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4062,23 +4170,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(93), 1,
       sym_line_comment,
-    ACTIONS(251), 2,
+    ACTIONS(229), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2754] = 6,
+      anon_sym_COMMA,
+  [2817] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(253), 1,
-      aux_sym_int_token2,
     STATE(94), 1,
       sym_line_comment,
-    STATE(109), 1,
-      sym_int,
-  [2773] = 5,
+    ACTIONS(240), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2835] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4087,10 +4196,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(95), 1,
       sym_line_comment,
-    ACTIONS(255), 2,
+    ACTIONS(64), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2790] = 5,
+      anon_sym_COMMA,
+  [2853] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4099,10 +4209,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(96), 1,
       sym_line_comment,
-    ACTIONS(211), 2,
+    ACTIONS(194), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2807] = 5,
+      anon_sym_COMMA,
+  [2871] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4111,23 +4222,24 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(97), 1,
       sym_line_comment,
-    ACTIONS(257), 2,
+    ACTIONS(245), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2824] = 6,
+      anon_sym_COMMA,
+  [2889] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(253), 1,
-      aux_sym_int_token2,
     STATE(98), 1,
       sym_line_comment,
-    STATE(110), 1,
-      sym_int,
-  [2843] = 5,
+    ACTIONS(270), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
+  [2907] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4136,66 +4248,23 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     STATE(99), 1,
       sym_line_comment,
-    ACTIONS(259), 2,
+    ACTIONS(272), 3,
       ts_builtin_sym_end,
       anon_sym_LF,
-  [2860] = 6,
+      anon_sym_COMMA,
+  [2925] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(47), 1,
-      anon_sym_POUND,
-    ACTIONS(253), 1,
-      aux_sym_int_token2,
-    STATE(89), 1,
-      sym_int,
     STATE(100), 1,
       sym_line_comment,
-  [2879] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(261), 1,
-      anon_sym_RPAREN,
-    STATE(101), 1,
-      sym_line_comment,
-  [2895] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(263), 1,
-      anon_sym_rel,
-    STATE(102), 1,
-      sym_line_comment,
-  [2911] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(265), 1,
-      anon_sym_LBRACK,
-    STATE(103), 1,
-      sym_line_comment,
-  [2927] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
-    ACTIONS(5), 1,
-      aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
-      sym_block_comment,
-    ACTIONS(267), 1,
-      anon_sym_RBRACK,
-    STATE(104), 1,
-      sym_line_comment,
+    ACTIONS(274), 3,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+      anon_sym_COMMA,
   [2943] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
@@ -4203,143 +4272,335 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(269), 1,
-      anon_sym_RPAREN,
+    STATE(101), 1,
+      sym_line_comment,
+    ACTIONS(216), 3,
+      anon_sym_COMMA,
+      anon_sym_DASH,
+      anon_sym_RBRACE,
+  [2961] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(102), 1,
+      sym_line_comment,
+    ACTIONS(276), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2978] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    STATE(103), 1,
+      sym_line_comment,
+    ACTIONS(278), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [2995] = 6,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(280), 1,
+      aux_sym_int_token2,
+    STATE(104), 1,
+      sym_line_comment,
+    STATE(117), 1,
+      sym_int,
+  [3014] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
     STATE(105), 1,
       sym_line_comment,
-  [2959] = 5,
+    ACTIONS(282), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [3031] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(215), 1,
-      anon_sym_RPAREN,
     STATE(106), 1,
       sym_line_comment,
-  [2975] = 5,
-    ACTIONS(271), 1,
-      anon_sym_POUND,
-    ACTIONS(273), 1,
-      aux_sym_line_comment_token1,
-    ACTIONS(275), 1,
+    ACTIONS(284), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [3048] = 6,
+    ACTIONS(5), 1,
       aux_sym_line_comment_token2,
-    ACTIONS(277), 1,
+    ACTIONS(7), 1,
       sym_block_comment,
+    ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(280), 1,
+      aux_sym_int_token2,
+    STATE(93), 1,
+      sym_int,
     STATE(107), 1,
       sym_line_comment,
-  [2991] = 5,
+  [3067] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(279), 1,
-      anon_sym_RPAREN,
     STATE(108), 1,
       sym_line_comment,
-  [3007] = 5,
+    ACTIONS(286), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [3084] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(239), 1,
-      anon_sym_RBRACK,
     STATE(109), 1,
       sym_line_comment,
-  [3023] = 5,
-    ACTIONS(3), 1,
-      anon_sym_POUND,
+    ACTIONS(211), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [3101] = 6,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(281), 1,
-      anon_sym_RBRACK,
+    ACTIONS(49), 1,
+      anon_sym_POUND,
+    ACTIONS(280), 1,
+      aux_sym_int_token2,
     STATE(110), 1,
       sym_line_comment,
-  [3039] = 5,
+    STATE(124), 1,
+      sym_int,
+  [3120] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(283), 1,
-      aux_sym_int_token1,
     STATE(111), 1,
       sym_line_comment,
-  [3055] = 5,
+    ACTIONS(288), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [3137] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(285), 1,
-      anon_sym_LBRACK,
     STATE(112), 1,
       sym_line_comment,
-  [3071] = 5,
-    ACTIONS(3), 1,
+    ACTIONS(218), 2,
+      ts_builtin_sym_end,
+      anon_sym_LF,
+  [3154] = 5,
+    ACTIONS(290), 1,
       anon_sym_POUND,
-    ACTIONS(5), 1,
+    ACTIONS(292), 1,
+      aux_sym_line_comment_token1,
+    ACTIONS(294), 1,
       aux_sym_line_comment_token2,
-    ACTIONS(7), 1,
+    ACTIONS(296), 1,
       sym_block_comment,
-    ACTIONS(287), 1,
-      anon_sym_ptr,
     STATE(113), 1,
       sym_line_comment,
-  [3087] = 5,
+  [3170] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(289), 1,
+    ACTIONS(298), 1,
       sym_float,
     STATE(114), 1,
       sym_line_comment,
-  [3103] = 5,
+  [3186] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(291), 1,
-      aux_sym_int_token1,
+    ACTIONS(300), 1,
+      anon_sym_RPAREN,
     STATE(115), 1,
       sym_line_comment,
-  [3119] = 5,
+  [3202] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(293), 1,
-      sym_string,
+    ACTIONS(302), 1,
+      anon_sym_RBRACK,
     STATE(116), 1,
       sym_line_comment,
-  [3135] = 5,
+  [3218] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(295), 1,
-      ts_builtin_sym_end,
+    ACTIONS(304), 1,
+      anon_sym_RBRACK,
     STATE(117), 1,
       sym_line_comment,
-  [3151] = 5,
+  [3234] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(306), 1,
+      anon_sym_LBRACK,
+    STATE(118), 1,
+      sym_line_comment,
+  [3250] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(308), 1,
+      anon_sym_RPAREN,
+    STATE(119), 1,
+      sym_line_comment,
+  [3266] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(310), 1,
+      aux_sym_int_token1,
+    STATE(120), 1,
+      sym_line_comment,
+  [3282] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(312), 1,
+      anon_sym_rel,
+    STATE(121), 1,
+      sym_line_comment,
+  [3298] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(314), 1,
+      sym_string,
+    STATE(122), 1,
+      sym_line_comment,
+  [3314] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(316), 1,
+      anon_sym_ptr,
+    STATE(123), 1,
+      sym_line_comment,
+  [3330] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(268), 1,
+      anon_sym_RBRACK,
+    STATE(124), 1,
+      sym_line_comment,
+  [3346] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(318), 1,
+      anon_sym_LBRACK,
+    STATE(125), 1,
+      sym_line_comment,
+  [3362] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(320), 1,
+      aux_sym_int_token1,
+    STATE(126), 1,
+      sym_line_comment,
+  [3378] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(322), 1,
+      anon_sym_RPAREN,
+    STATE(127), 1,
+      sym_line_comment,
+  [3394] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(247), 1,
+      anon_sym_RPAREN,
+    STATE(128), 1,
+      sym_line_comment,
+  [3410] = 5,
+    ACTIONS(3), 1,
+      anon_sym_POUND,
+    ACTIONS(5), 1,
+      aux_sym_line_comment_token2,
+    ACTIONS(7), 1,
+      sym_block_comment,
+    ACTIONS(324), 1,
+      ts_builtin_sym_end,
+    STATE(129), 1,
+      sym_line_comment,
+  [3426] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
@@ -4348,309 +4609,335 @@ static const uint16_t ts_small_parse_table[] = {
       sym_block_comment,
     ACTIONS(23), 1,
       anon_sym_COLON,
-    STATE(118), 1,
+    STATE(130), 1,
       sym_line_comment,
-  [3167] = 5,
+  [3442] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(297), 1,
+    ACTIONS(326), 1,
       sym_word,
-    STATE(119), 1,
+    STATE(131), 1,
       sym_line_comment,
-  [3183] = 5,
+  [3458] = 5,
     ACTIONS(3), 1,
       anon_sym_POUND,
     ACTIONS(5), 1,
       aux_sym_line_comment_token2,
     ACTIONS(7), 1,
       sym_block_comment,
-    ACTIONS(299), 1,
+    ACTIONS(328), 1,
       sym_word,
-    STATE(120), 1,
+    STATE(132), 1,
       sym_line_comment,
-  [3199] = 1,
-    ACTIONS(301), 1,
+  [3474] = 1,
+    ACTIONS(330), 1,
       ts_builtin_sym_end,
-  [3203] = 1,
-    ACTIONS(303), 1,
+  [3478] = 1,
+    ACTIONS(332), 1,
       ts_builtin_sym_end,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(3)] = 0,
-  [SMALL_STATE(4)] = 63,
-  [SMALL_STATE(5)] = 126,
-  [SMALL_STATE(6)] = 185,
-  [SMALL_STATE(7)] = 225,
-  [SMALL_STATE(8)] = 259,
-  [SMALL_STATE(9)] = 293,
-  [SMALL_STATE(10)] = 326,
-  [SMALL_STATE(11)] = 363,
-  [SMALL_STATE(12)] = 396,
-  [SMALL_STATE(13)] = 432,
-  [SMALL_STATE(14)] = 470,
-  [SMALL_STATE(15)] = 512,
-  [SMALL_STATE(16)] = 544,
+  [SMALL_STATE(4)] = 67,
+  [SMALL_STATE(5)] = 134,
+  [SMALL_STATE(6)] = 197,
+  [SMALL_STATE(7)] = 237,
+  [SMALL_STATE(8)] = 271,
+  [SMALL_STATE(9)] = 305,
+  [SMALL_STATE(10)] = 342,
+  [SMALL_STATE(11)] = 375,
+  [SMALL_STATE(12)] = 408,
+  [SMALL_STATE(13)] = 450,
+  [SMALL_STATE(14)] = 488,
+  [SMALL_STATE(15)] = 524,
+  [SMALL_STATE(16)] = 558,
   [SMALL_STATE(17)] = 590,
   [SMALL_STATE(18)] = 622,
-  [SMALL_STATE(19)] = 656,
-  [SMALL_STATE(20)] = 702,
-  [SMALL_STATE(21)] = 746,
-  [SMALL_STATE(22)] = 793,
-  [SMALL_STATE(23)] = 839,
-  [SMALL_STATE(24)] = 869,
-  [SMALL_STATE(25)] = 899,
-  [SMALL_STATE(26)] = 929,
-  [SMALL_STATE(27)] = 973,
-  [SMALL_STATE(28)] = 1019,
-  [SMALL_STATE(29)] = 1049,
-  [SMALL_STATE(30)] = 1088,
-  [SMALL_STATE(31)] = 1127,
-  [SMALL_STATE(32)] = 1166,
-  [SMALL_STATE(33)] = 1205,
-  [SMALL_STATE(34)] = 1244,
-  [SMALL_STATE(35)] = 1283,
-  [SMALL_STATE(36)] = 1322,
-  [SMALL_STATE(37)] = 1361,
-  [SMALL_STATE(38)] = 1400,
-  [SMALL_STATE(39)] = 1443,
-  [SMALL_STATE(40)] = 1482,
-  [SMALL_STATE(41)] = 1521,
-  [SMALL_STATE(42)] = 1548,
-  [SMALL_STATE(43)] = 1577,
-  [SMALL_STATE(44)] = 1608,
-  [SMALL_STATE(45)] = 1635,
-  [SMALL_STATE(46)] = 1672,
-  [SMALL_STATE(47)] = 1705,
-  [SMALL_STATE(48)] = 1740,
-  [SMALL_STATE(49)] = 1772,
-  [SMALL_STATE(50)] = 1804,
-  [SMALL_STATE(51)] = 1831,
-  [SMALL_STATE(52)] = 1861,
-  [SMALL_STATE(53)] = 1885,
-  [SMALL_STATE(54)] = 1915,
-  [SMALL_STATE(55)] = 1941,
-  [SMALL_STATE(56)] = 1967,
-  [SMALL_STATE(57)] = 1990,
-  [SMALL_STATE(58)] = 2013,
-  [SMALL_STATE(59)] = 2036,
-  [SMALL_STATE(60)] = 2057,
-  [SMALL_STATE(61)] = 2078,
-  [SMALL_STATE(62)] = 2099,
-  [SMALL_STATE(63)] = 2122,
-  [SMALL_STATE(64)] = 2145,
-  [SMALL_STATE(65)] = 2168,
-  [SMALL_STATE(66)] = 2191,
-  [SMALL_STATE(67)] = 2214,
-  [SMALL_STATE(68)] = 2237,
-  [SMALL_STATE(69)] = 2260,
-  [SMALL_STATE(70)] = 2281,
-  [SMALL_STATE(71)] = 2302,
-  [SMALL_STATE(72)] = 2325,
-  [SMALL_STATE(73)] = 2346,
-  [SMALL_STATE(74)] = 2371,
-  [SMALL_STATE(75)] = 2394,
-  [SMALL_STATE(76)] = 2417,
-  [SMALL_STATE(77)] = 2442,
-  [SMALL_STATE(78)] = 2465,
-  [SMALL_STATE(79)] = 2486,
-  [SMALL_STATE(80)] = 2504,
-  [SMALL_STATE(81)] = 2524,
-  [SMALL_STATE(82)] = 2542,
-  [SMALL_STATE(83)] = 2560,
-  [SMALL_STATE(84)] = 2578,
-  [SMALL_STATE(85)] = 2596,
-  [SMALL_STATE(86)] = 2614,
-  [SMALL_STATE(87)] = 2632,
-  [SMALL_STATE(88)] = 2650,
-  [SMALL_STATE(89)] = 2668,
-  [SMALL_STATE(90)] = 2686,
-  [SMALL_STATE(91)] = 2703,
-  [SMALL_STATE(92)] = 2720,
-  [SMALL_STATE(93)] = 2737,
-  [SMALL_STATE(94)] = 2754,
-  [SMALL_STATE(95)] = 2773,
-  [SMALL_STATE(96)] = 2790,
-  [SMALL_STATE(97)] = 2807,
-  [SMALL_STATE(98)] = 2824,
-  [SMALL_STATE(99)] = 2843,
-  [SMALL_STATE(100)] = 2860,
-  [SMALL_STATE(101)] = 2879,
-  [SMALL_STATE(102)] = 2895,
-  [SMALL_STATE(103)] = 2911,
-  [SMALL_STATE(104)] = 2927,
-  [SMALL_STATE(105)] = 2943,
-  [SMALL_STATE(106)] = 2959,
-  [SMALL_STATE(107)] = 2975,
-  [SMALL_STATE(108)] = 2991,
-  [SMALL_STATE(109)] = 3007,
-  [SMALL_STATE(110)] = 3023,
-  [SMALL_STATE(111)] = 3039,
-  [SMALL_STATE(112)] = 3055,
-  [SMALL_STATE(113)] = 3071,
-  [SMALL_STATE(114)] = 3087,
-  [SMALL_STATE(115)] = 3103,
-  [SMALL_STATE(116)] = 3119,
-  [SMALL_STATE(117)] = 3135,
-  [SMALL_STATE(118)] = 3151,
-  [SMALL_STATE(119)] = 3167,
-  [SMALL_STATE(120)] = 3183,
-  [SMALL_STATE(121)] = 3199,
-  [SMALL_STATE(122)] = 3203,
+  [SMALL_STATE(19)] = 668,
+  [SMALL_STATE(20)] = 712,
+  [SMALL_STATE(21)] = 758,
+  [SMALL_STATE(22)] = 805,
+  [SMALL_STATE(23)] = 836,
+  [SMALL_STATE(24)] = 880,
+  [SMALL_STATE(25)] = 910,
+  [SMALL_STATE(26)] = 940,
+  [SMALL_STATE(27)] = 986,
+  [SMALL_STATE(28)] = 1032,
+  [SMALL_STATE(29)] = 1062,
+  [SMALL_STATE(30)] = 1101,
+  [SMALL_STATE(31)] = 1140,
+  [SMALL_STATE(32)] = 1179,
+  [SMALL_STATE(33)] = 1218,
+  [SMALL_STATE(34)] = 1257,
+  [SMALL_STATE(35)] = 1296,
+  [SMALL_STATE(36)] = 1335,
+  [SMALL_STATE(37)] = 1378,
+  [SMALL_STATE(38)] = 1417,
+  [SMALL_STATE(39)] = 1456,
+  [SMALL_STATE(40)] = 1495,
+  [SMALL_STATE(41)] = 1534,
+  [SMALL_STATE(42)] = 1571,
+  [SMALL_STATE(43)] = 1606,
+  [SMALL_STATE(44)] = 1639,
+  [SMALL_STATE(45)] = 1670,
+  [SMALL_STATE(46)] = 1697,
+  [SMALL_STATE(47)] = 1724,
+  [SMALL_STATE(48)] = 1753,
+  [SMALL_STATE(49)] = 1785,
+  [SMALL_STATE(50)] = 1817,
+  [SMALL_STATE(51)] = 1844,
+  [SMALL_STATE(52)] = 1874,
+  [SMALL_STATE(53)] = 1898,
+  [SMALL_STATE(54)] = 1928,
+  [SMALL_STATE(55)] = 1954,
+  [SMALL_STATE(56)] = 1980,
+  [SMALL_STATE(57)] = 2006,
+  [SMALL_STATE(58)] = 2032,
+  [SMALL_STATE(59)] = 2058,
+  [SMALL_STATE(60)] = 2081,
+  [SMALL_STATE(61)] = 2102,
+  [SMALL_STATE(62)] = 2125,
+  [SMALL_STATE(63)] = 2150,
+  [SMALL_STATE(64)] = 2173,
+  [SMALL_STATE(65)] = 2196,
+  [SMALL_STATE(66)] = 2219,
+  [SMALL_STATE(67)] = 2242,
+  [SMALL_STATE(68)] = 2263,
+  [SMALL_STATE(69)] = 2286,
+  [SMALL_STATE(70)] = 2309,
+  [SMALL_STATE(71)] = 2330,
+  [SMALL_STATE(72)] = 2353,
+  [SMALL_STATE(73)] = 2376,
+  [SMALL_STATE(74)] = 2399,
+  [SMALL_STATE(75)] = 2422,
+  [SMALL_STATE(76)] = 2445,
+  [SMALL_STATE(77)] = 2466,
+  [SMALL_STATE(78)] = 2491,
+  [SMALL_STATE(79)] = 2514,
+  [SMALL_STATE(80)] = 2537,
+  [SMALL_STATE(81)] = 2558,
+  [SMALL_STATE(82)] = 2579,
+  [SMALL_STATE(83)] = 2604,
+  [SMALL_STATE(84)] = 2625,
+  [SMALL_STATE(85)] = 2646,
+  [SMALL_STATE(86)] = 2671,
+  [SMALL_STATE(87)] = 2689,
+  [SMALL_STATE(88)] = 2707,
+  [SMALL_STATE(89)] = 2725,
+  [SMALL_STATE(90)] = 2743,
+  [SMALL_STATE(91)] = 2761,
+  [SMALL_STATE(92)] = 2779,
+  [SMALL_STATE(93)] = 2799,
+  [SMALL_STATE(94)] = 2817,
+  [SMALL_STATE(95)] = 2835,
+  [SMALL_STATE(96)] = 2853,
+  [SMALL_STATE(97)] = 2871,
+  [SMALL_STATE(98)] = 2889,
+  [SMALL_STATE(99)] = 2907,
+  [SMALL_STATE(100)] = 2925,
+  [SMALL_STATE(101)] = 2943,
+  [SMALL_STATE(102)] = 2961,
+  [SMALL_STATE(103)] = 2978,
+  [SMALL_STATE(104)] = 2995,
+  [SMALL_STATE(105)] = 3014,
+  [SMALL_STATE(106)] = 3031,
+  [SMALL_STATE(107)] = 3048,
+  [SMALL_STATE(108)] = 3067,
+  [SMALL_STATE(109)] = 3084,
+  [SMALL_STATE(110)] = 3101,
+  [SMALL_STATE(111)] = 3120,
+  [SMALL_STATE(112)] = 3137,
+  [SMALL_STATE(113)] = 3154,
+  [SMALL_STATE(114)] = 3170,
+  [SMALL_STATE(115)] = 3186,
+  [SMALL_STATE(116)] = 3202,
+  [SMALL_STATE(117)] = 3218,
+  [SMALL_STATE(118)] = 3234,
+  [SMALL_STATE(119)] = 3250,
+  [SMALL_STATE(120)] = 3266,
+  [SMALL_STATE(121)] = 3282,
+  [SMALL_STATE(122)] = 3298,
+  [SMALL_STATE(123)] = 3314,
+  [SMALL_STATE(124)] = 3330,
+  [SMALL_STATE(125)] = 3346,
+  [SMALL_STATE(126)] = 3362,
+  [SMALL_STATE(127)] = 3378,
+  [SMALL_STATE(128)] = 3394,
+  [SMALL_STATE(129)] = 3410,
+  [SMALL_STATE(130)] = 3426,
+  [SMALL_STATE(131)] = 3442,
+  [SMALL_STATE(132)] = 3458,
+  [SMALL_STATE(133)] = 3474,
+  [SMALL_STATE(134)] = 3478,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(133),
   [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
   [9] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 0, 0, 0),
-  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(120),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
+  [11] = {.entry = {.count = 1, .reusable = false}}, SHIFT(132),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(131),
   [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
   [17] = {.entry = {.count = 1, .reusable = false}}, SHIFT(21),
-  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(118),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(130),
   [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 1, 0, 1),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [27] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
-  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
-  [35] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(81),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
-  [41] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
-  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, 0, 1),
-  [47] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
-  [51] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
-  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [57] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, 0, 1),
-  [59] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__expr, 1, 0, 0), REDUCE(sym__tc_expr, 1, 0, 0),
-  [62] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1, 0, 0),
-  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
-  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tc_expr, 1, 0, 0),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(123),
+  [31] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [37] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(95),
+  [41] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [43] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [45] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 3, 0, 1),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
+  [59] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 4, 0, 1),
+  [61] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym__expr, 1, 0, 0), REDUCE(sym__tc_expr, 1, 0, 0),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expr, 1, 0, 0),
+  [66] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
   [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__tc_expr, 1, 0, 0),
-  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1, 0, 0),
-  [72] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_int, 1, 0, 0),
-  [74] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 2, 0, 0),
-  [76] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_int, 2, 0, 0),
-  [78] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ident, 1, 0, 0),
-  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ident, 1, 0, 0),
-  [82] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1, 0, 0),
-  [84] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_reg, 1, 0, 0),
-  [86] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tc_infix, 3, 0, 5),
-  [88] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tc_infix, 3, 0, 5),
-  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
-  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [98] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
-  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
-  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [70] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__tc_expr, 1, 0, 0),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 2, 0, 0),
+  [74] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_int, 2, 0, 0),
+  [76] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_int, 1, 0, 0),
+  [78] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_int, 1, 0, 0),
+  [80] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_reg, 1, 0, 0),
+  [82] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_reg, 1, 0, 0),
+  [84] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ident, 1, 0, 0),
+  [86] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_ident, 1, 0, 0),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tc_infix, 3, 0, 5),
+  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tc_infix, 3, 0, 5),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [94] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [96] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
   [104] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [106] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
-  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, 0, 1),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0),
-  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(111),
-  [117] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(7),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(15),
-  [123] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(11),
-  [126] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(9),
-  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 1, 0, 1),
-  [131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
-  [133] = {.entry = {.count = 1, .reusable = false}}, SHIFT(68),
-  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(71),
-  [137] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2, 0, 0),
-  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
-  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3, 0, 0),
-  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_const, 3, 0, 4),
-  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
-  [155] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
-  [159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0),
-  [161] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0), SHIFT_REPEAT(52),
-  [164] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0),
-  [166] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
-  [170] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
-  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 3),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 0),
-  [180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, 0, 1),
-  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0),
-  [188] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0), SHIFT_REPEAT(100),
-  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5, 0, 0),
-  [193] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
-  [195] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0),
-  [197] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0), SHIFT_REPEAT(116),
-  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
-  [204] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0),
-  [206] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0), SHIFT_REPEAT(52),
-  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [106] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [108] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 1, 0, 0),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0),
+  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(120),
+  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(8),
+  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(17),
+  [121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(10),
+  [124] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_instruction_repeat2, 2, 0, 0), SHIFT_REPEAT(11),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_instruction, 2, 0, 1),
+  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 1, 0, 1),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [135] = {.entry = {.count = 1, .reusable = false}}, SHIFT(69),
+  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(72),
+  [139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 3, 0, 0),
+  [141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 2, 0, 0),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_const, 3, 0, 4),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [153] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [155] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [161] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0),
+  [163] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0), SHIFT_REPEAT(52),
+  [166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 2, 0, 0),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
+  [172] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_program_repeat1, 1, 0, 0),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 0),
+  [182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 3),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 3, 0, 1),
+  [192] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0),
+  [196] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat3, 2, 0, 0), SHIFT_REPEAT(122),
+  [199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1, 0, 0),
+  [201] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [203] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [205] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 5, 0, 0),
+  [207] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [209] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
   [211] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_meta, 2, 0, 1),
-  [213] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3, 0, 0),
-  [215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0),
-  [219] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
-  [222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_program, 1, 0, 0),
-  [224] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [226] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [228] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
-  [232] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0),
-  [234] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0), SHIFT_REPEAT(114),
-  [237] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [239] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
-  [241] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7, 0, 0),
-  [243] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 6, 0, 0),
-  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4, 0, 0),
-  [247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 0),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1, 0, 0),
-  [251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 2),
-  [253] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [255] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 3),
-  [257] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 3, 0, 3),
-  [259] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 3, 0, 0),
-  [261] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [263] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [265] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [267] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [271] = {.entry = {.count = 1, .reusable = false}}, SHIFT(107),
-  [273] = {.entry = {.count = 1, .reusable = false}}, SHIFT(122),
-  [275] = {.entry = {.count = 1, .reusable = false}}, SHIFT(121),
-  [277] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
-  [279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [281] = {.entry = {.count = 1, .reusable = true}}, SHIFT(60),
-  [283] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [285] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [287] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
-  [291] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [293] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [295] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [297] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [299] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [301] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1, 0, 0),
-  [303] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2, 0, 0),
+  [213] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_list_repeat1, 2, 0, 0), SHIFT_REPEAT(75),
+  [216] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_list_repeat1, 2, 0, 0),
+  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0),
+  [220] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_program_repeat2, 2, 0, 0), SHIFT_REPEAT(52),
+  [223] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
+  [225] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [227] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [229] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0),
+  [231] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat1, 2, 0, 0), SHIFT_REPEAT(107),
+  [234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [236] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [238] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [240] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0),
+  [242] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_meta_repeat2, 2, 0, 0), SHIFT_REPEAT(114),
+  [245] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 3, 0, 0),
+  [247] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0),
+  [251] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_instruction_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
+  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 7, 0, 0),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 5, 0, 0),
+  [262] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 3, 0, 0),
+  [264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 4, 0, 0),
+  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [270] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 2, 0, 0),
+  [272] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_ptr, 6, 0, 0),
+  [274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 4, 0, 0),
+  [276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 2, 0, 2),
+  [278] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 3),
+  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
+  [282] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 3, 0, 0),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 5, 0, 0),
+  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__item, 1, 0, 0),
+  [288] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_label, 3, 0, 3),
+  [290] = {.entry = {.count = 1, .reusable = false}}, SHIFT(113),
+  [292] = {.entry = {.count = 1, .reusable = false}}, SHIFT(134),
+  [294] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
+  [296] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
+  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
+  [324] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [330] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 1, 0, 0),
+  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_line_comment, 2, 0, 0),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/instr_and_reg.test
+++ b/test/corpus/instr_and_reg.test
@@ -132,6 +132,26 @@ adr X1, helloworld
               (word)))))
 
 ==========
+Instruction -- List of registers with range (ARMv7)
+==========
+PUSH { V1, V2, V3-V5, LR }
+---
+(program
+  (instruction
+    (word)
+    (list
+      (reg
+        (word))
+      (reg
+        (word))
+      (reg
+        (word))
+      (reg
+        (word))
+      (reg
+        (word)))))
+
+==========
 Instruction -- Section address arg, reg arg (GAS x86)
 ==========
 mov $msg, %ecx


### PR DESCRIPTION
Hi, would it be possible to add support for ARMv7 lists of registers? The following provides an example of this feature.

For `PUSH { V1, V2, LR }`:

**Before:**
```
(program ; [0, 0] - [1, 0]
  (instruction ; [0, 0] - [0, 17]
    kind: (word) ; [0, 0] - [0, 4]
    (ERROR ; [0, 5] - [0, 6]
      (ERROR)) ; [0, 5] - [0, 6]
    (ident ; [0, 7] - [0, 9]
      (reg ; [0, 7] - [0, 9]
        (word))) ; [0, 7] - [0, 9]
    (ident ; [0, 11] - [0, 13]
      (reg ; [0, 11] - [0, 13]
        (word))) ; [0, 11] - [0, 13]
    (ident ; [0, 15] - [0, 17]
      (reg ; [0, 15] - [0, 17]
        (word)))) ; [0, 15] - [0, 17]
  (ERROR ; [0, 18] - [0, 19]
    (ERROR))) ; [0, 18] - [0, 19]
```

**After:**
```
(program ; [0, 0] - [1, 0]
  (instruction ; [0, 0] - [0, 19]
    kind: (word) ; [0, 0] - [0, 4]
    (list ; [0, 5] - [0, 19]
      (reg ; [0, 7] - [0, 9]
        (word)) ; [0, 7] - [0, 9]
      (reg ; [0, 11] - [0, 13]
        (word)) ; [0, 11] - [0, 13]
      (reg ; [0, 15] - [0, 17]
        (word))))) ; [0, 15] - [0, 17]
```

Thank you very much!